### PR TITLE
Fixes AWS openapi configuration

### DIFF
--- a/terraform/environment/api/openapi_spec.json
+++ b/terraform/environment/api/openapi_spec.json
@@ -32,9 +32,6 @@
             "description": "202 response",
             "schema": {
               "$ref": "#/definitions/PutMetricsResponse"
-            },
-            "default": {
-              "status": "Processing"
             }
           },
           "404": {

--- a/terraform/environment/api/openapi_spec.json
+++ b/terraform/environment/api/openapi_spec.json
@@ -32,6 +32,9 @@
             "description": "202 response",
             "schema": {
               "$ref": "#/definitions/PutMetricsResponse"
+            },
+            "default": {
+              "status": "Processing"
             }
           },
           "404": {
@@ -162,8 +165,14 @@
       "title": "OPG Metrics successfule response definition.",
       "description": "Confirms the data was accepted by the system and is processing the data.",
       "type": "object",
-      "default": {
-        "status": "Processing"
+      "properties": {
+        "status": {
+          "type": "string",
+          "title": "Message to return on success",
+          "description": "Gives confirmation to the client that a request has been accepted.",
+          "maxLength": 20,
+          "pattern": "^[a-zA-Z-_]{1,20}$"
+        }
       }
     }
   }


### PR DESCRIPTION
# Purpose

AWS does not completely conform to OpenAPI standards. The use of default responses has caused issues when defined in a schema. This fix removes it.

Fixes Ticket: MET-30

## Approach

Manually imported the existing OpenAPI schema into API Gateway, saw this failed and made amends as needed for it to pass on import.

## Learning

We need to find the best way to validate against the capabilities of API Gateway on future changes. Or as discussed with @andrewpearce-digital potentially having a development environment be deployed on PRs to see breaking changes before going to live.

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
