### PR TITLE
MET-32 Removes test resource and correctly sets stage deployments

### DIFF
--- a/terraform/environment/api-gateway.tf
+++ b/terraform/environment/api-gateway.tf
@@ -15,13 +15,7 @@ resource "aws_api_gateway_deployment" "kinesis_stream_api_gateway" {
 resource "aws_api_gateway_stage" "kinesis_stream_api_gateway" {
   deployment_id = aws_api_gateway_deployment.kinesis_stream_api_gateway.id
   rest_api_id   = aws_api_gateway_rest_api.kinesis_stream_api_gateway.id
-  stage_name    = "prod"
-}
-
-resource "aws_api_gateway_stage" "kinesis_stream_api_gateway_dev" {
-  deployment_id = aws_api_gateway_deployment.kinesis_stream_api_gateway.id
-  rest_api_id   = aws_api_gateway_rest_api.kinesis_stream_api_gateway.id
-  stage_name    = "dev"
+  stage_name    = terraform.workspace
 }
 
 resource "aws_api_gateway_rest_api" "kinesis_stream_api_gateway" {

--- a/terraform/environment/api-gateway.tf
+++ b/terraform/environment/api-gateway.tf
@@ -1,33 +1,27 @@
-resource "aws_api_gateway_stage" "kinesis_stream_api_gateway" {
-  stage_name    = "prod"
-  rest_api_id   = aws_api_gateway_rest_api.kinesis_stream_api_gateway.id
-  deployment_id = aws_api_gateway_deployment.kinesis_stream_api_gateway.id
-}
-
 resource "aws_api_gateway_deployment" "kinesis_stream_api_gateway" {
-  depends_on  = [aws_api_gateway_integration.kinesis_stream_api_gateway]
   rest_api_id = aws_api_gateway_rest_api.kinesis_stream_api_gateway.id
-  stage_name  = "dev"
+
+  triggers = {
+    redeployment = sha1(jsonencode(aws_api_gateway_rest_api.kinesis_stream_api_gateway.body))
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  stage_name = ""
 }
 
-resource "aws_api_gateway_resource" "kinesis_stream_api_gateway" {
-  rest_api_id = aws_api_gateway_rest_api.kinesis_stream_api_gateway.id
-  parent_id   = aws_api_gateway_rest_api.kinesis_stream_api_gateway.root_resource_id
-  path_part   = "mytestresource"
-}
-
-resource "aws_api_gateway_method" "kinesis_stream_api_gateway" {
+resource "aws_api_gateway_stage" "kinesis_stream_api_gateway" {
+  deployment_id = aws_api_gateway_deployment.kinesis_stream_api_gateway.id
   rest_api_id   = aws_api_gateway_rest_api.kinesis_stream_api_gateway.id
-  resource_id   = aws_api_gateway_resource.kinesis_stream_api_gateway.id
-  http_method   = "GET"
-  authorization = "NONE"
+  stage_name    = "prod"
 }
 
-resource "aws_api_gateway_integration" "kinesis_stream_api_gateway" {
-  rest_api_id = aws_api_gateway_rest_api.kinesis_stream_api_gateway.id
-  resource_id = aws_api_gateway_resource.kinesis_stream_api_gateway.id
-  http_method = aws_api_gateway_method.kinesis_stream_api_gateway.http_method
-  type        = "MOCK"
+resource "aws_api_gateway_stage" "kinesis_stream_api_gateway_dev" {
+  deployment_id = aws_api_gateway_deployment.kinesis_stream_api_gateway.id
+  rest_api_id   = aws_api_gateway_rest_api.kinesis_stream_api_gateway.id
+  stage_name    = "dev"
 }
 
 resource "aws_api_gateway_rest_api" "kinesis_stream_api_gateway" {

--- a/terraform/environment/api/openapi_spec.json
+++ b/terraform/environment/api/openapi_spec.json
@@ -28,6 +28,12 @@
           }
         ],
         "responses": {
+          "200": {
+            "description": "200 response",
+            "schema": {
+              "$ref": "#/definitions/PutMetricsResponse"
+            }
+          },
           "202": {
             "description": "202 response",
             "schema": {
@@ -47,11 +53,8 @@
           "credentials": "${allowed_roles}",
           "uri": "arn:aws:apigateway:${region}:kinesis:action/PutRecords",
           "responses": {
-            "default": {
-              "statusCode": "200",
-              "responseTemplates" : {
-                "application/json" : "{ \"status\": \"Processing\" }"
-            }
+            "200": {
+              "statusCode": "200"
             }
           },
           "requestTemplates": {


### PR DESCRIPTION
# Purpose

Stages within TF were not being published after being applied and there are some rogue test resources being created.

Fixes Ticket: MET-32

## Approach

Set the correct resources for prod and dev stages and ensure they trigger a deployment to set them as the current stage instead of just adding to the history of the stage.

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
