### PR TITLE
Removes AWS4Auth from securityDefinitions

### DIFF
--- a/scripts/pipeline/post_to_api/post_to_api.py
+++ b/scripts/pipeline/post_to_api/post_to_api.py
@@ -17,12 +17,12 @@ class APIGatewayCaller:
         self.choose_target_gateway(target_production)
         self.set_iam_role_session()
         self.api_gateway_stage = os.getenv('TF_WORKSPACE', "development")
-        self.aws_auth = AWS4Auth(
-            self.aws_iam_session['Credentials']['AccessKeyId'],
-            self.aws_iam_session['Credentials']['SecretAccessKey'],
-            'eu-west-1',
-            'execute-api',
-            session_token=self.aws_iam_session['Credentials']['SessionToken'])
+        #self.aws_auth = AWS4Auth(
+            #self.aws_iam_session['Credentials']['AccessKeyId'],
+            #self.aws_iam_session['Credentials']['SecretAccessKey'],
+            #'eu-west-1',
+            #'execute-api',
+            #session_token=self.aws_iam_session['Credentials']['SessionToken'])
 
     def choose_target_gateway(self, target_production):
         if target_production:
@@ -60,7 +60,6 @@ class APIGatewayCaller:
         response = requests.request(
             method=method,
             url=url+path,
-            auth=self.aws_auth,
             json=json_data,
             headers=headers
         )

--- a/terraform/environment/api/openapi_spec.json
+++ b/terraform/environment/api/openapi_spec.json
@@ -71,12 +71,6 @@
       "type" : "apiKey",
       "name" : "x-api-key",
       "in" : "header"
-    },
-    "sigv4" : {
-      "type" : "apiKey",
-      "name" : "Authorization",
-      "in" : "header",
-      "x-amazon-apigateway-authtype" : "awsSigv4"
     }
   },
   "definitions": {


### PR DESCRIPTION
# Purpose

Removes the need for 2 authentication methods to just use an api key rather than AWS4Auth

## Approach

Removes the definition from the open api spec and the test script

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
