### PR TITLE
Changes the limit on a metric from 15 to 25 characters

### DIFF
--- a/terraform/environment/api/openapi_spec.json
+++ b/terraform/environment/api/openapi_spec.json
@@ -123,28 +123,28 @@
                     "type": "string",
                     "title": "The service or project name.",
                     "description": "Gives the ability to query against a particular service to know the purpose of this metric.",
-                    "maxLength": 15,
+                    "maxLength": 25,
                     "pattern": "^[a-zA-Z-_]{1,25}$"
                   },
                   "Category": {
                     "type": "string",
                     "title": "Assign metric a Category (Optional)",
                     "description": "Optionally tag the metric with a Category to better enable finer grouping of data.",
-                    "maxLength": 15,
+                    "maxLength": 25,
                     "pattern": "^[a-zA-Z-_]{1,25}$"
                   },
                   "Subcategory": {
                     "type": "string",
                     "title": "Assign metric a Subcategory (Optional)",
                     "description": "Optionally tag the metric with a Subcategory to better enable finer grouping of data.",
-                    "maxLength": 15,
+                    "maxLength": 25,
                     "pattern": "^[a-zA-Z-_]{1,25}$"
                   },
                   "MeasureName": {
                     "type": "string",
                     "title": "The metric name",
                     "description": "The name of the metric you want to record the measure under.",
-                    "maxLength": 15,
+                    "maxLength": 25,
                     "pattern": "^[a-zA-Z-_]{1,25}$"
                   },
                   "MeasureValue": {

--- a/terraform/environment/api/openapi_spec.json
+++ b/terraform/environment/api/openapi_spec.json
@@ -124,28 +124,28 @@
                     "title": "The service or project name.",
                     "description": "Gives the ability to query against a particular service to know the purpose of this metric.",
                     "maxLength": 15,
-                    "pattern": "^[a-zA-Z-_]{1,15}$"
+                    "pattern": "^[a-zA-Z-_]{1,25}$"
                   },
                   "Category": {
                     "type": "string",
                     "title": "Assign metric a Category (Optional)",
                     "description": "Optionally tag the metric with a Category to better enable finer grouping of data.",
                     "maxLength": 15,
-                    "pattern": "^[a-zA-Z-_]{1,15}$"
+                    "pattern": "^[a-zA-Z-_]{1,25}$"
                   },
                   "Subcategory": {
                     "type": "string",
                     "title": "Assign metric a Subcategory (Optional)",
                     "description": "Optionally tag the metric with a Subcategory to better enable finer grouping of data.",
                     "maxLength": 15,
-                    "pattern": "^[a-zA-Z-_]{1,15}$"
+                    "pattern": "^[a-zA-Z-_]{1,25}$"
                   },
                   "MeasureName": {
                     "type": "string",
                     "title": "The metric name",
                     "description": "The name of the metric you want to record the measure under.",
                     "maxLength": 15,
-                    "pattern": "^[a-zA-Z-_]{1,15}$"
+                    "pattern": "^[a-zA-Z-_]{1,25}$"
                   },
                   "MeasureValue": {
                     "type": "string",


### PR DESCRIPTION
# Purpose

Changes the limit on a metric from 15 to 25 characters

## Approach

Real life usage needs greater field length options in metric data being passed. This updates the max length in the API spec.


## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
