### PR TITLE
Specify regional api gateway domain name

### DIFF
--- a/terraform/environment/dns.tf
+++ b/terraform/environment/dns.tf
@@ -18,6 +18,9 @@ resource "aws_route53_record" "opg_metrics" {
 resource "aws_api_gateway_domain_name" "opg_metrics" {
   certificate_arn = aws_acm_certificate_validation.certificate_view.certificate_arn
   domain_name     = "${local.dns_namespace_env}api.${data.aws_route53_zone.opg_metrics.name}"
+  endpoint_configuration {
+    types = ["REGIONAL"]
+  }
 }
 
 resource "aws_route53_record" "certificate_validation_view" {


### PR DESCRIPTION
# Purpose

We get the following error currently when building the infra

```
Error: Error creating API Gateway Domain Name: BadRequestException: Invalid certificate ARN: arn:aws:acm:eu-west-1:679638075911:certificate/b7f2e63f-c53a-48b5-b86d-f0a54a39a6cf. Certificate must be in 'us-east-1'.

  on dns.tf line 18, in resource "aws_api_gateway_domain_name" "opg_metrics":
  18: resource "aws_api_gateway_domain_name" "opg_metrics" {
```

We actually need to specify that it should be regional instead of edge by default, otherwise certs from us-east-1 can only be used.

## Learning

Explained above

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
