### PR TITLE
Change api gateway domain cert to be regional

### DIFF
--- a/terraform/environment/api-keys.tf
+++ b/terraform/environment/api-keys.tf
@@ -18,9 +18,9 @@ resource "aws_api_gateway_usage_plan" "trusted_services" {
   }
 
   quota_settings {
-    limit  = 20
+    limit  = 4000
     offset = 2
-    period = "WEEK"
+    period = "DAY"
   }
 
   throttle_settings {

--- a/terraform/environment/dns.tf
+++ b/terraform/environment/dns.tf
@@ -19,6 +19,7 @@ resource "aws_route53_record" "opg_metrics" {
 resource "aws_api_gateway_domain_name" "opg_metrics" {
   regional_certificate_arn = aws_acm_certificate_validation.certificate_view.certificate_arn
   domain_name              = "${local.dns_namespace_env}api.${data.aws_route53_zone.opg_metrics.name}"
+  security_policy          = "TLS_1_2"
   endpoint_configuration {
     types = ["REGIONAL"]
   }

--- a/terraform/environment/dns.tf
+++ b/terraform/environment/dns.tf
@@ -16,8 +16,8 @@ resource "aws_route53_record" "opg_metrics" {
 }
 
 resource "aws_api_gateway_domain_name" "opg_metrics" {
-  certificate_arn = aws_acm_certificate_validation.certificate_view.certificate_arn
-  domain_name     = "${local.dns_namespace_env}api.${data.aws_route53_zone.opg_metrics.name}"
+  regional_certificate_arn = aws_acm_certificate_validation.certificate_view.certificate_arn
+  domain_name              = "${local.dns_namespace_env}api.${data.aws_route53_zone.opg_metrics.name}"
   endpoint_configuration {
     types = ["REGIONAL"]
   }

--- a/terraform/environment/dns.tf
+++ b/terraform/environment/dns.tf
@@ -4,6 +4,7 @@ data "aws_route53_zone" "opg_metrics" {
 }
 
 resource "aws_route53_record" "opg_metrics" {
+  provider = aws.management
   # <environment.>api.metrics.opg.service.justice.gov.uk
   name    = "${local.dns_namespace_env}api.${data.aws_route53_zone.opg_metrics.name}"
   type    = "A"


### PR DESCRIPTION
# Purpose

The certificate generated for the API gateway should be assigned as a regional cert. 

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
