### PR TITLE
Add Environment option to metric data

### DIFF
--- a/terraform/environment/api/examples/put_metrics.json
+++ b/terraform/environment/api/examples/put_metrics.json
@@ -22,6 +22,7 @@
         "Project": "opgtest",
         "Category": "client",
         "Subcategory": "webvitals",
+        "Environment": "development",
         "MeasureName": "cumulative_layout_shift",
         "MeasureValue": "1.1",
         "Time": "1609240692533"

--- a/terraform/environment/api/openapi_spec.json
+++ b/terraform/environment/api/openapi_spec.json
@@ -140,6 +140,13 @@
                     "maxLength": 25,
                     "pattern": "^[a-zA-Z-_]{1,25}$"
                   },
+                  "Environment": {
+                    "type": "string",
+                    "title": "Sets the environment the metric has come from (Optional)",
+                    "description": "Optionally sets the environment the metric has come from, e.g. development, preproduction, live.",
+                    "maxLength": 25,
+                    "pattern": "^[a-zA-Z-_]{1,25}$"
+                  },
                   "MeasureName": {
                     "type": "string",
                     "title": "The metric name",
@@ -169,7 +176,7 @@
       }
     },
     "PutMetricsResponse": {
-      "title": "OPG Metrics successfule response definition.",
+      "title": "OPG Metrics successful response definition.",
       "description": "Confirms the data was accepted by the system and is processing the data.",
       "type": "object",
       "properties": {


### PR DESCRIPTION
# Purpose

Adds the OpenAPI optional parameter Environment to be sent with Metrics

Fixes Ticket: UML-1605

## Approach

Add the property to the OpenAPI Spec to be consumed by API Gateway

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [x] I have added tests to prove my work
* [ ] The product team have tested these changes
