### PR TITLE
UML-1871 - Rotate API Keys on a schedule

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,12 +216,9 @@ orbs:
                 terraform --version
                 cd ~/project/terraform/<<parameters.configuration_path>>
                 terraform init
+                terraform state list | grep aws_iam_access_key |sed 's/*//g'
                 all_aws_access_keys=$(terraform state list | grep aws_iam_access_key |sed 's/*//g')
-                for access_key in $all_aws_access_keys
-                do
-                  echo $access_key
-
-                done
+                echo $all_aws_access_keys
 
 jobs:
   cancel_redundant_builds:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,16 +12,16 @@ workflows:
     jobs:
       - opg-metrics/rotate_api_keys:
           name: taint api keys
+          workspace: development
+          configuration_path: environment
+          filters: { branches: { only: [main] } }
+
+      - opg-metrics/terraform_command:
+            name: replace api keys
             workspace: development
             configuration_path: environment
+            terraform_command: apply
             filters: { branches: { only: [main] } }
-
-        - opg-metrics/terraform_command:
-              name: replace api keys
-              workspace: development
-              configuration_path: environment
-              terraform_command: apply
-              filters: { branches: { only: [main] } }
 
   pr_build:
       jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,62 +15,62 @@ workflows:
 
   pr_build:
       jobs:
-        - cancel_redundant_builds:
-            name: cancel previous jobs
-            filters: { branches: { ignore: [main] } }
+        # - cancel_redundant_builds:
+        #     name: cancel previous jobs
+        #     filters: { branches: { ignore: [main] } }
 
         - opg-metrics/rotate_api_keys:
             name: rotate_api_keys
             workspace: development
             configuration_path: environment
 
-        - opg-metrics/docker_build_lambda_image:
-            name: build ship-to-opg-metrics lambda image
-            lambda_name: ship-to-opg-metrics
-            filters: { branches: { ignore: [main] } }
-            requires: [cancel previous jobs]
+        # - opg-metrics/docker_build_lambda_image:
+        #     name: build ship-to-opg-metrics lambda image
+        #     lambda_name: ship-to-opg-metrics
+        #     filters: { branches: { ignore: [main] } }
+        #     requires: [cancel previous jobs]
 
-        - opg-metrics/docker_build_lambda_image:
-            name: build clsf-to-sqs lambda image
-            lambda_name: clsf-to-sqs
-            filters: { branches: { ignore: [main] } }
-            requires: [cancel previous jobs]
+        # - opg-metrics/docker_build_lambda_image:
+        #     name: build clsf-to-sqs lambda image
+        #     lambda_name: clsf-to-sqs
+        #     filters: { branches: { ignore: [main] } }
+        #     requires: [cancel previous jobs]
 
-        - opg-metrics/terraform_command:
-            name: lint shared terraform
-            workspace: development
-            configuration_path: account
-            terraform_command: validate
-            filters: { branches: { ignore: [main] } }
-            requires: [cancel previous jobs]
+        # - opg-metrics/terraform_command:
+        #     name: lint shared terraform
+        #     workspace: development
+        #     configuration_path: account
+        #     terraform_command: validate
+        #     filters: { branches: { ignore: [main] } }
+        #     requires: [cancel previous jobs]
 
-        - opg-metrics/terraform_command:
-            name: lint service terraform
-            workspace: development
-            configuration_path: environment
-            terraform_command: validate
-            filters: { branches: { ignore: [main] } }
-            requires: [cancel previous jobs]
+        # - opg-metrics/terraform_command:
+        #     name: lint service terraform
+        #     workspace: development
+        #     configuration_path: environment
+        #     terraform_command: validate
+        #     filters: { branches: { ignore: [main] } }
+        #     requires: [cancel previous jobs]
 
-        - opg-metrics/terraform_command:
-            name: plan shared terraform
-            workspace: development
-            configuration_path: account
-            terraform_command: plan
-            filters: { branches: { ignore: [main] } }
-            requires: [
-              lint shared terraform,
-              ]
+        # - opg-metrics/terraform_command:
+        #     name: plan shared terraform
+        #     workspace: development
+        #     configuration_path: account
+        #     terraform_command: plan
+        #     filters: { branches: { ignore: [main] } }
+        #     requires: [
+        #       lint shared terraform,
+        #       ]
 
-        - opg-metrics/terraform_command:
-            name: plan service terraform
-            workspace: development
-            configuration_path: environment
-            terraform_command: plan
-            filters: { branches: { ignore: [main] } }
-            requires: [
-              lint service terraform,
-              ]
+        # - opg-metrics/terraform_command:
+        #     name: plan service terraform
+        #     workspace: development
+        #     configuration_path: environment
+        #     terraform_command: plan
+        #     filters: { branches: { ignore: [main] } }
+        #     requires: [
+        #       lint service terraform,
+        #       ]
 
   path_to_live:
       jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,13 +216,9 @@ orbs:
                 terraform --version
                 cd ~/project/terraform/<<parameters.configuration_path>>
                 terraform init
-                terraform workspace <<parameters.workspace>>
-                terraform state list
+                terraform state list | grep aws_api_gateway_api_key | sed 's/*//g'
 
-          - run:
-              name: terraform state list
-              command: |
-                terraform state list
+
 
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,11 +216,8 @@ orbs:
                 terraform --version
                 cd ~/project/terraform/<<parameters.configuration_path>>
                 terraform init
-                terraform state list
-                terraform state list | grep aws_iam_access_key
-                terraform state list | grep aws_iam_access_key | sed 's/*//g'
-                all_aws_access_keys=$(terraform state list | grep aws_iam_access_key |sed 's/*//g')
-                echo $all_aws_access_keys
+                # terraform state list
+
 
 jobs:
   cancel_redundant_builds:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,7 +216,9 @@ orbs:
                 terraform --version
                 cd ~/project/terraform/<<parameters.configuration_path>>
                 terraform init
-                terraform state list | grep aws_iam_access_key |sed 's/*//g'
+                terraform state list
+                terraform state list | grep aws_iam_access_key
+                terraform state list | grep aws_iam_access_key | sed 's/*//g'
                 all_aws_access_keys=$(terraform state list | grep aws_iam_access_key |sed 's/*//g')
                 echo $all_aws_access_keys
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,7 +216,12 @@ orbs:
                 terraform --version
                 cd ~/project/terraform/<<parameters.configuration_path>>
                 terraform init
-                # terraform state list
+                terraform state list
+
+          - run:
+              name: terraform state list
+              command: |
+                terraform state list
 
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,7 +216,11 @@ orbs:
                 terraform --version
                 cd ~/project/terraform/<<parameters.configuration_path>>
                 terraform init
-                terraform state list | grep aws_api_gateway_api_key | sed 's/*//g'
+                all_aws_access_keys=$(terraform state list | grep aws_api_gateway_api_key | sed 's/*//g')
+                for access_key in $all_aws_access_keys
+                do
+                  echo $access_key
+                done
 
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,17 +1,27 @@
 version: 2.1
 
 workflows:
-  # rotate_api_keys:
-  #   triggers:
-  #     - schedule:
-  #         cron: "0 3 * * *" # Every 3am
-  #         filters:
-  #           branches:
-  #             only:
-  #               - main
-  #   jobs:
-  #     - opg-metrics/rotate_api_keys:
-  #         name: rotate_api_keys
+  rotate_api_keys:
+    triggers:
+      - schedule:
+          cron: "0 3 * * *" # Every 3am
+          filters:
+            branches:
+              only:
+                - main
+    jobs:
+      - opg-metrics/rotate_api_keys:
+          name: taint api keys
+            workspace: development
+            configuration_path: environment
+            filters: { branches: { only: [main] } }
+
+        - opg-metrics/terraform_command:
+              name: replace api keys
+              workspace: development
+              configuration_path: environment
+              terraform_command: apply
+              filters: { branches: { only: [main] } }
 
   pr_build:
       jobs:
@@ -219,7 +229,7 @@ orbs:
                 all_aws_access_keys=$(terraform state list | grep aws_api_gateway_api_key | sed 's/*//g')
                 for access_key in $all_aws_access_keys
                 do
-                  echo $access_key
+                  terraform taint $access_key
                 done
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,6 +216,7 @@ orbs:
                 terraform --version
                 cd ~/project/terraform/<<parameters.configuration_path>>
                 terraform init
+                terraform workspace <<parameters.workspace>>
                 terraform state list
 
           - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,28 @@
 version: 2.1
 
 workflows:
+  # rotate_api_keys:
+  #   triggers:
+  #     - schedule:
+  #         cron: "0 3 * * *" # Every 3am
+  #         filters:
+  #           branches:
+  #             only:
+  #               - main
+  #   jobs:
+  #     - opg-metrics/rotate_api_keys:
+  #         name: rotate_api_keys
+
   pr_build:
       jobs:
         - cancel_redundant_builds:
             name: cancel previous jobs
             filters: { branches: { ignore: [main] } }
+
+        - opg-metrics/rotate_api_keys:
+            name: rotate_api_keys
+            workspace: development
+            configuration_path: environment
 
         - opg-metrics/docker_build_lambda_image:
             name: build ship-to-opg-metrics lambda image
@@ -125,10 +142,10 @@ orbs:
             description: Terraform workspace name
             type: string
           configuration_path:
-            description: Terraform workspace name
+            description: Terraform configuration path
             type: string
           terraform_command:
-            description: Terraform workspace name
+            description: Terraform command to execute
             type: string
         environment:
           TF_WORKSPACE: "<<parameters.workspace>>"
@@ -177,6 +194,34 @@ orbs:
                 else
                   docker push ${ECR_URL}:${IMAGE_TAG}
                 fi
+
+      rotate_api_keys:
+        executor: terraform
+        parameters:
+          workspace:
+            description: Terraform workspace name
+            type: string
+          configuration_path:
+            description: Terraform configuration path
+            type: string
+        environment:
+          TF_WORKSPACE: "<<parameters.workspace>>"
+          TF_CLI_ARGS_plan: "-lock-timeout=300s"
+          TF_CLI_ARGS_apply: "-lock-timeout=300s -auto-approve"
+        steps:
+          - checkout
+          - run:
+              name: terraform taint api keys
+              command: |
+                terraform --version
+                cd ~/project/terraform/<<parameters.configuration_path>>
+                terraform init
+                all_aws_access_keys=$(terraform state list | grep aws_iam_access_key |sed 's/*//g')
+                for access_key in $all_aws_access_keys
+                do
+                  echo $access_key
+
+                done
 
 jobs:
   cancel_redundant_builds:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,62 +25,57 @@ workflows:
 
   pr_build:
       jobs:
-        # - cancel_redundant_builds:
-        #     name: cancel previous jobs
-        #     filters: { branches: { ignore: [main] } }
+        - cancel_redundant_builds:
+            name: cancel previous jobs
+            filters: { branches: { ignore: [main] } }
 
-        - opg-metrics/rotate_api_keys:
-            name: rotate_api_keys
+        - opg-metrics/docker_build_lambda_image:
+            name: build ship-to-opg-metrics lambda image
+            lambda_name: ship-to-opg-metrics
+            filters: { branches: { ignore: [main] } }
+            requires: [cancel previous jobs]
+
+        - opg-metrics/docker_build_lambda_image:
+            name: build clsf-to-sqs lambda image
+            lambda_name: clsf-to-sqs
+            filters: { branches: { ignore: [main] } }
+            requires: [cancel previous jobs]
+
+        - opg-metrics/terraform_command:
+            name: lint shared terraform
+            workspace: development
+            configuration_path: account
+            terraform_command: validate
+            filters: { branches: { ignore: [main] } }
+            requires: [cancel previous jobs]
+
+        - opg-metrics/terraform_command:
+            name: lint service terraform
             workspace: development
             configuration_path: environment
+            terraform_command: validate
+            filters: { branches: { ignore: [main] } }
+            requires: [cancel previous jobs]
 
-        # - opg-metrics/docker_build_lambda_image:
-        #     name: build ship-to-opg-metrics lambda image
-        #     lambda_name: ship-to-opg-metrics
-        #     filters: { branches: { ignore: [main] } }
-        #     requires: [cancel previous jobs]
+        - opg-metrics/terraform_command:
+            name: plan shared terraform
+            workspace: development
+            configuration_path: account
+            terraform_command: plan
+            filters: { branches: { ignore: [main] } }
+            requires: [
+              lint shared terraform,
+              ]
 
-        # - opg-metrics/docker_build_lambda_image:
-        #     name: build clsf-to-sqs lambda image
-        #     lambda_name: clsf-to-sqs
-        #     filters: { branches: { ignore: [main] } }
-        #     requires: [cancel previous jobs]
-
-        # - opg-metrics/terraform_command:
-        #     name: lint shared terraform
-        #     workspace: development
-        #     configuration_path: account
-        #     terraform_command: validate
-        #     filters: { branches: { ignore: [main] } }
-        #     requires: [cancel previous jobs]
-
-        # - opg-metrics/terraform_command:
-        #     name: lint service terraform
-        #     workspace: development
-        #     configuration_path: environment
-        #     terraform_command: validate
-        #     filters: { branches: { ignore: [main] } }
-        #     requires: [cancel previous jobs]
-
-        # - opg-metrics/terraform_command:
-        #     name: plan shared terraform
-        #     workspace: development
-        #     configuration_path: account
-        #     terraform_command: plan
-        #     filters: { branches: { ignore: [main] } }
-        #     requires: [
-        #       lint shared terraform,
-        #       ]
-
-        # - opg-metrics/terraform_command:
-        #     name: plan service terraform
-        #     workspace: development
-        #     configuration_path: environment
-        #     terraform_command: plan
-        #     filters: { branches: { ignore: [main] } }
-        #     requires: [
-        #       lint service terraform,
-        #       ]
+        - opg-metrics/terraform_command:
+            name: plan service terraform
+            workspace: development
+            configuration_path: environment
+            terraform_command: plan
+            filters: { branches: { ignore: [main] } }
+            requires: [
+              lint service terraform,
+              ]
 
   path_to_live:
       jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,14 +14,12 @@ workflows:
           name: taint api keys
           workspace: development
           configuration_path: environment
-          filters: { branches: { only: [main] } }
 
       - opg-metrics/terraform_command:
             name: replace api keys
             workspace: development
             configuration_path: environment
             terraform_command: apply
-            filters: { branches: { only: [main] } }
 
   pr_build:
       jobs:


### PR DESCRIPTION
# Purpose

Automate a security stance by replacing API keys on a regular basis.

Fixes Ticket: UML-1871

## Approach

- Create a new job lists api keys in terraform state and taints them
- Add a workflow that runs the taint and apply jobs on a schedule

## Learning

- https://circleci.com/docs/2.0/configuration-reference/#schedule
- https://www.terraform.io/docs/cli/commands/taint.html

## Checklist

* [x] I have performed a self-review of my own code
* [x] The product team have tested these changes
