### PR TITLE
Uml 1988 enable pytest ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,11 +32,13 @@ workflows:
             name: test ship-to-opg-metrics lambda
             lambda_name: ship-to-opg-metrics
             filters: { branches: { ignore: [main] } }
+            requires: [cancel previous jobs]
 
         - opg-metrics/test_lambda:
             name: test clsf-to-sqs lambda
             lambda_name: clsf-to-sqs
             filters: { branches: { ignore: [main] } }
+            requires: [cancel previous jobs]
 
         - opg-metrics/docker_build_lambda_image:
             name: build ship-to-opg-metrics lambda image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,7 +126,7 @@ orbs:
         steps:
           - run:
               name: Install pytest
-              command: pip install pytest
+              command: pip install pytest mock
       install_aws_cli:
         steps:
           - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,11 @@ workflows:
             name: cancel previous jobs
             filters: { branches: { ignore: [main] } }
 
+        - opg-metrics/test_lambda:
+            name: test ship-to-opg-metrics lambda
+            lambda_name: ship-to-opg-metrics
+            filters: { branches: { ignore: [main] } }
+
         - opg-metrics/docker_build_lambda_image:
             name: build ship-to-opg-metrics lambda image
             lambda_name: ship-to-opg-metrics
@@ -117,6 +122,11 @@ orbs:
         docker: [image: cimg/python:3.8]
         resource_class: small
     commands:
+      install_pytest:
+        steps:
+          - run:
+              name: Install pytest
+              command: pip install pytest
       install_aws_cli:
         steps:
           - run:
@@ -198,6 +208,21 @@ orbs:
                 else
                   docker push ${ECR_URL}:${IMAGE_TAG}
                 fi
+
+      test_lambda:
+        executor: python
+        parameters:
+          lambda_name:
+            type: string
+        steps:
+          - checkout
+          - install_pytest
+          - run:
+              name: Run Tests
+              command: |
+                cd ~/project/lambda/<<parameters.configuration_path>>
+                pip install -r requirements_dev.txt
+                pytest
 
       rotate_api_keys:
         executor: terraform

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,7 +220,7 @@ orbs:
           - run:
               name: Run Tests
               command: |
-                cd ~/project/lambda/<<parameters.lambda_name>>
+                cd ~/project/lambda/<<parameters.lambda_name>>/src
                 pip install -r requirements_dev.txt
                 pytest
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,7 +222,7 @@ orbs:
               command: |
                 cd ~/project/lambda/<<parameters.lambda_name>>/src
                 pip install -r requirements_dev.txt
-                pytest --junitxml=results/test_results.xml
+                pytest --junitxml=results/pytest/results.xml
           - store_test_results:
               path: results/
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,11 @@ workflows:
             lambda_name: ship-to-opg-metrics
             filters: { branches: { ignore: [main] } }
 
+        - opg-metrics/test_lambda:
+            name: test clsf-to-sqs lambda
+            lambda_name: clsf-to-sqs
+            filters: { branches: { ignore: [main] } }
+
         - opg-metrics/docker_build_lambda_image:
             name: build ship-to-opg-metrics lambda image
             lambda_name: ship-to-opg-metrics

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,7 +222,9 @@ orbs:
               command: |
                 cd ~/project/lambda/<<parameters.lambda_name>>/src
                 pip install -r requirements_dev.txt
-                pytest
+                pytest --junitxml=results/test_results.xml
+          - store_artifacts:
+              path: results/
 
       rotate_api_keys:
         executor: terraform

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,7 +220,7 @@ orbs:
           - run:
               name: Run Tests
               command: |
-                cd ~/project/lambda/<<parameters.configuration_path>>
+                cd ~/project/lambda/<<parameters.lambda_name>>
                 pip install -r requirements_dev.txt
                 pytest
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,7 +224,7 @@ orbs:
                 pip install -r requirements_dev.txt
                 pytest --junitxml=results/pytest/results.xml
           - store_test_results:
-              path: results/
+              path: ~/project/lambda/<<parameters.lambda_name>>/src/results/
 
       rotate_api_keys:
         executor: terraform

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,7 +223,7 @@ orbs:
                 cd ~/project/lambda/<<parameters.lambda_name>>/src
                 pip install -r requirements_dev.txt
                 pytest --junitxml=results/test_results.xml
-          - store_artifacts:
+          - store_test_results:
               path: results/
 
       rotate_api_keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,13 +44,13 @@ workflows:
             name: build ship-to-opg-metrics lambda image
             lambda_name: ship-to-opg-metrics
             filters: { branches: { ignore: [main] } }
-            requires: [cancel previous jobs]
+            requires: [cancel previous jobs, test clsf-to-sqs lambda, test ship-to-opg-metrics lambda]
 
         - opg-metrics/docker_build_lambda_image:
             name: build clsf-to-sqs lambda image
             lambda_name: clsf-to-sqs
             filters: { branches: { ignore: [main] } }
-            requires: [cancel previous jobs]
+            requires: [cancel previous jobs, test clsf-to-sqs lambda, test ship-to-opg-metrics lambda]
 
         - opg-metrics/terraform_command:
             name: lint shared terraform
@@ -90,15 +90,27 @@ workflows:
 
   path_to_live:
       jobs:
+        - opg-metrics/test_lambda:
+            name: test ship-to-opg-metrics lambda
+            lambda_name: ship-to-opg-metrics
+            filters: { branches: { only: [main] } }
+
+        - opg-metrics/test_lambda:
+            name: test clsf-to-sqs lambda
+            lambda_name: clsf-to-sqs
+            filters: { branches: { only: [main] } }
+
         - opg-metrics/docker_build_lambda_image:
             name: build ship-to-opg-metrics lambda image
             lambda_name: ship-to-opg-metrics
             filters: { branches: { only: [main] } }
+            requires: [test clsf-to-sqs lambda, test ship-to-opg-metrics lambda]
 
         - opg-metrics/docker_build_lambda_image:
             name: build clsf-to-sqs lambda image
             lambda_name: clsf-to-sqs
             filters: { branches: { only: [main] } }
+            requires: [test clsf-to-sqs lambda, test ship-to-opg-metrics lambda]
 
         - opg-metrics/terraform_command:
             name: apply shared terraform

--- a/lambda/clsf-to-sqs/src/requirements_dev.txt
+++ b/lambda/clsf-to-sqs/src/requirements_dev.txt
@@ -1,4 +1,4 @@
-moto[sqs]==2.2.12
-coverage==5.5
-pylint==2.7.2
-pytest==6.2.2
+moto[sqs]==2.3.0
+coverage==6.2
+pylint==2.12.2
+pytest==6.2.5

--- a/lambda/clsf-to-sqs/src/test_main.py
+++ b/lambda/clsf-to-sqs/src/test_main.py
@@ -15,7 +15,7 @@ AWS_REGION = 'eu-west-1'
 PAYLOAD = {'awslogs': {'data': 'H4sIAAAAAAAAAFVS22rjMBD9laDXjRNdfJED+xCatCxsm9JkWZZ1MYokpwbZciU73RDy7x3bCXQNxjozc47PzOiMKu29OOjdqdFogVbL3TJ/XG+3y4c1miL7UWsHYRYnnEQpxzFLIWzs4cHZroFMwmlXGcIozUXTmFKKtrR1DhV+LNy2Tovqv8rZsdQf2gVAmHVeB6IOTCPmAOeFYixhes+YisIoZLwQsZR7iVUqFSn6n/tu76Urm/4/96VptfNo8feLfCCNL4LWBv7dBwpaMFao3HdVJdwJvQ6u1kddtz3vjEo1NEjSiPM4DeOQpiHlFDMchjihNOIJYSQGmGIS8zTlJExIEkYx4xz8tCWMsBUVTIPElOEkTXAETUxvowX5c3YDGVpkaNtJCbDojDlNDhpmLFqtJs+r+4mo1aRx2oM9iBTWTW4dTCjGGZpmSFrI/WtBCWR130gurRqVV5vfTz83y1W+/fX4uHz5cyUMWeBfABmgmB5G+IbyWlQj/2mz+3G3Hllvoq6HygwpXYjOtENcgde+5yFBMSUBjgOc7Ei0oBxUZ9A7TcJvGC+uhsGsE6PdojQjcdi2d3J+Z6vK1sNxq92xlHr+rIr+vcJZ89YMMqasey6hvW9phPeD0iiQwXMl9EegXz+3YK9QdLXsr83Ac/q9g8VByb2z1dcycCt1UKqh7MXa9jsJYrzXbE/iAK4A7FirkFOh0hAzWOWeRkWGLhd0eb18AinNXL1SAwAA'}}
 
 
-@mock.patch.dict(os.environ, {'AWS_DEFAULT_REGION': AWS_REGION, 'METRIC_CATEGORY': METRIC_CATEGORY, 'METRIC_SUBCATEGORY': METRIC_SUBCATEGORY, 'METRIC_ENVIRONMENT': METRIC_ENVIRONMENT, 'METRIC_PROJECT_NAME': METRIC_PROJECT_NAME, 'QUEUE_URL': QUEUE_URL})
+@mock.patch.dict(os.environ, {'AWS_DEFAULT_REGION': AWS_REGION, 'METRIC_CATEGORY': METRIC_CATEGORY, 'METRIC_SUBCATEGORY': METRIC_SUBCATEGORY, 'METRIC_ENVIRONMENT': METRIC_ENVIRONMENT, 'METRIC_PROJECT_NAME': METRIC_PROJECT_NAME, 'QUEUE_URL': 'https://eu-west-1.queue.amazonaws.com/123456789012/' + QUEUE_URL})
 @mock_sqs
 class TestLambdaFunction(unittest.TestCase):
 
@@ -23,22 +23,7 @@ class TestLambdaFunction(unittest.TestCase):
         from main import handler
 
         sqs = boto3.client("sqs", region_name=AWS_REGION)
-
-        dlq_url = sqs.create_queue(QueueName=QUEUE_URL)["QueueUrl"]
-        dlq_arn = sqs.get_queue_attributes(QueueUrl=dlq_url)[
-            "Attributes"]["QueueArn"]
-
-        attributes = {
-            "DelaySeconds": "900",
-            "MaximumMessageSize": "262144",
-            "MessageRetentionPeriod": "1209600",
-            "ReceiveMessageWaitTimeSeconds": "20",
-            "RedrivePolicy": '{"deadLetterTargetArn": "%s", "maxReceiveCount": 100}'
-            % (dlq_arn),
-            "VisibilityTimeout": "43200",
-        }
-
-        sqs.create_queue(QueueName=QUEUE_NAME, Attributes=attributes)
+        sqs.create_queue(QueueName=QUEUE_URL)
 
         event = PAYLOAD
 

--- a/lambda/ship-to-opg-metrics/src/requirements_dev.txt
+++ b/lambda/ship-to-opg-metrics/src/requirements_dev.txt
@@ -1,6 +1,6 @@
-moto[sqs]==2.2.12
-moto[secretsmanager]==2.2.12
-coverage==5.5
-pylint==2.7.2
-pytest==6.2.2
+moto[sqs]==2.3.0
+moto[secretsmanager]==2.3.0
+coverage==6.2
+pylint==2.12.2
+pytest==6.2.5
 requests-mock


### PR DESCRIPTION
# Purpose

Adds the python tests to the CI pipeline on a PR build for both lambdas

Fixes Ticket: UML-1988

## Approach

Followed existing pattern in CircleCI config for installing requirements and running replicating local method.

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [x] I have added tests to prove my work
