### PR TITLE
Met 49 build java

### DIFF
--- a/.github/workflows/apache-flink.yml
+++ b/.github/workflows/apache-flink.yml
@@ -1,0 +1,23 @@
+name: Build and Publish Apache Flink kinesis connector
+
+on:
+  push:
+    branches:
+      - "main"
+  schedule:
+    # Every Tuesday, at 09:20 UTC
+    - cron: '20 9 * * 2'
+# Based on https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-maven
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+      - name: Build with Maven
+        run: mvn --batch-mode --update-snapshots package

--- a/.github/workflows/apache_flink_job.yml
+++ b/.github/workflows/apache_flink_job.yml
@@ -1,12 +1,8 @@
 name: Build and Publish Apache Flink kinesis connector
 
 on:
-  push:
-    branches:
-      - "main"
-  schedule:
-    # Every Tuesday, at 09:20 UTC
-    - cron: '20 9 * * 2'
+  workflow_call:
+
 # Based on https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-maven
 jobs:
   build:
@@ -14,10 +10,18 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        id: checkout_code
+        with:
+          repository: 'aws-samples/amazon-kinesis-data-analytics-java-examples'
+
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
           java-version: '11'
           distribution: 'adopt'
       - name: Build with Maven
-        run: mvn --batch-mode --update-snapshots package
+        run: |
+          cd integrations/flink_connector/sample-kinesis-to-timestream-app
+          mvn clean compile && mvn package
+
+# Built jar file in target/sample-kinesis-to-timestream-app-0.1-SNAPSHOT-shaded.jar

--- a/.github/workflows/apache_flink_job.yml
+++ b/.github/workflows/apache_flink_job.yml
@@ -30,5 +30,3 @@ jobs:
         with:
           name: kinesis-to-timestream-app
           path: integrations/flink_connector/sample-kinesis-to-timestream-app/target/sample-kinesis-to-timestream-app-0.1-SNAPSHOT.jar
-
-# Built jar file in integrations/flink_connector/sample-kinesis-to-timestream-app/target/sample-kinesis-to-timestream-app-0.1-SNAPSHOT.jar

--- a/.github/workflows/apache_flink_job.yml
+++ b/.github/workflows/apache_flink_job.yml
@@ -26,7 +26,6 @@ jobs:
       - name: Build with Maven
         id: maven_build
         run: |
-          ls
           cd integrations/flink_connector/sample-kinesis-to-timestream-app
           mvn clean compile && mvn package -Djar.finalName=opg-metrics-kinesis-to-timestream-app
           echo ::set-output name=artifact_name::opg-metrics-kinesis-to-timestream-app

--- a/.github/workflows/apache_flink_job.yml
+++ b/.github/workflows/apache_flink_job.yml
@@ -13,6 +13,7 @@ jobs:
         id: checkout_code
         with:
           repository: 'aws-samples/amazon-kinesis-data-analytics-java-examples'
+          ref: 'mainline'
 
       - name: Set up JDK 11
         uses: actions/setup-java@v3
@@ -21,6 +22,7 @@ jobs:
           distribution: 'adopt'
       - name: Build with Maven
         run: |
+          ls
           cd integrations/flink_connector/sample-kinesis-to-timestream-app
           mvn clean compile && mvn package
 

--- a/.github/workflows/apache_flink_job.yml
+++ b/.github/workflows/apache_flink_job.yml
@@ -2,6 +2,11 @@ name: Build and Publish Apache Flink kinesis connector
 
 on:
   workflow_call:
+    secrets:
+      aws_access_key_id_actions:
+        required: true
+      aws_secret_access_key_actions:
+        required: true
 
 # Based on https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-maven
 jobs:
@@ -25,5 +30,11 @@ jobs:
           ls
           cd integrations/flink_connector/sample-kinesis-to-timestream-app
           mvn clean compile && mvn package
+      - uses: shallwefootball/s3-upload-action@master
+        with:
+          aws_key_id: ${{ secrets.aws_access_key_id_actions }}
+          aws_secret_access_key: ${{ secrets.aws_secret_access_key_actions}}
+          aws_bucket: 'opg-metrics'
+          source_dir: 'integrations/flink_connector/sample-kinesis-to-timestream-app/target'
 
-# Built jar file in target/sample-kinesis-to-timestream-app-0.1-SNAPSHOT-shaded.jar
+# Built jar file in integrations/flink_connector/sample-kinesis-to-timestream-app/target/sample-kinesis-to-timestream-app-0.1-SNAPSHOT.jar

--- a/.github/workflows/apache_flink_job.yml
+++ b/.github/workflows/apache_flink_job.yml
@@ -2,13 +2,7 @@ name: Build and Publish Apache Flink kinesis connector
 
 on:
   workflow_call:
-    secrets:
-      aws_access_key_id_actions:
-        required: true
-      aws_secret_access_key_actions:
-        required: true
 
-# Based on https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-maven
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -30,11 +24,11 @@ jobs:
           ls
           cd integrations/flink_connector/sample-kinesis-to-timestream-app
           mvn clean compile && mvn package
-      - uses: shallwefootball/s3-upload-action@master
+      - name: Upload Apache Flink Jar
+        id: upload
+        uses: actions/upload-artifact@v3
         with:
-          aws_key_id: ${{ secrets.aws_access_key_id_actions }}
-          aws_secret_access_key: ${{ secrets.aws_secret_access_key_actions}}
-          aws_bucket: 'opg-metrics'
-          source_dir: 'integrations/flink_connector/sample-kinesis-to-timestream-app/target'
+          name: kinesis-to-timestream-app
+          path: integrations/flink_connector/sample-kinesis-to-timestream-app/target/sample-kinesis-to-timestream-app-0.1-SNAPSHOT.jar
 
 # Built jar file in integrations/flink_connector/sample-kinesis-to-timestream-app/target/sample-kinesis-to-timestream-app-0.1-SNAPSHOT.jar

--- a/.github/workflows/apache_flink_job.yml
+++ b/.github/workflows/apache_flink_job.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
         id: checkout_code
         with:
-          repository: 'aws-samples/amazon-kinesis-data-analytics-java-examples'
+          repository: 'awslabs/amazon-timestream-tools'
           ref: 'mainline'
 
       - name: Set up JDK 11

--- a/.github/workflows/apache_flink_job.yml
+++ b/.github/workflows/apache_flink_job.yml
@@ -2,6 +2,10 @@ name: Build and Publish Apache Flink kinesis connector
 
 on:
   workflow_call:
+    outputs:
+      artifact_name:
+        description: "Uploaded artifact name"
+        value: ${{ jobs.build.outputs.artifact_name }}
 
 jobs:
   build:
@@ -20,13 +24,17 @@ jobs:
           java-version: '11'
           distribution: 'adopt'
       - name: Build with Maven
+        id: maven_build
         run: |
           ls
           cd integrations/flink_connector/sample-kinesis-to-timestream-app
-          mvn clean compile && mvn package
+          mvn clean compile && mvn package -Djar.finalName=opg-metrics-kinesis-to-timestream-app
+          echo ::set-output name=artifact_name::opg-metrics-kinesis-to-timestream-app
       - name: Upload Apache Flink Jar
         id: upload
         uses: actions/upload-artifact@v3
         with:
-          name: kinesis-to-timestream-app
-          path: integrations/flink_connector/sample-kinesis-to-timestream-app/target/sample-kinesis-to-timestream-app-0.1-SNAPSHOT.jar
+          name: ${{ steps.maven_build.outputs.artifact_name }}
+          path: integrations/flink_connector/sample-kinesis-to-timestream-app/target/${{ steps.maven_build.outputs.artifact_name }}.jar
+    outputs:
+      artifact_name: ${{ steps.maven_build.outputs.artifact_name }}

--- a/.github/workflows/data-parse-branch-name.yml
+++ b/.github/workflows/data-parse-branch-name.yml
@@ -1,0 +1,61 @@
+# Generate Branch Names from GITHUB data
+name: "[Data - Parse] Branch Name"
+
+on:
+  workflow_dispatch:
+  workflow_call:
+    inputs:
+      push_to_github_env:
+        description: 'Boolean to push the clean branch name into $GITHUB_ENV as $BRANCH_NAME'
+        type: boolean
+        default: true
+    outputs:
+      raw_branch_name:
+        description: 'Raw branch name with slashes and other non alphanumeric chars left in place'
+        value: ${{ jobs.extract.outputs.raw_branch }}
+      parsed_branch_name:
+        description: 'Parsed branch name with ONLY alphanumeric chars.'
+        value: ${{ jobs.extract.outputs.parsed_branch }}
+
+permissions:
+  contents: read
+  security-events: none
+  pull-requests: none
+  actions: none
+  checks: none
+  deployments: none
+  issues: none
+  packages: none
+  repository-projects: none
+  statuses: none
+
+jobs:
+  extract:
+    name: 'Use github data to generate a clean branch name'
+    runs-on: ubuntu-latest
+    outputs:
+      raw_branch: ${{ steps.parse.outputs.raw_branch }}
+      parsed_branch: ${{ steps.parse.outputs.parsed_branch }}
+    steps:
+      - id: parse
+        name: Parse branch name
+        run: |
+          if [ "${{ github.head_ref}}" == "" ]; then
+            raw_branch="main"
+            parsed_branch="main"
+          else
+            raw_branch=${{ github.head_ref }}
+            parsed_branch=$( echo "${raw_branch}" | tr -cd '[:alnum:]')
+          fi
+          echo "EVENT: ${GITHUB_EVENT_NAME}"
+          echo "REF: ${{ github.head_ref }}"
+          echo "RAW BRANCH: ${raw_branch}"
+          echo "PARSED BRANCH: ${parsed_branch}"
+
+          echo "::set-output name=raw_branch::${raw_branch}"
+          echo "::set-output name=parsed_branch::${parsed_branch}"
+
+      - name: Push to GITHUB_ENV
+        if: inputs.push_to_github_env
+        run: |
+          echo BRANCH_NAME=${{ steps.parse.outputs.parsed_branch }} >> $GITHUB_ENV

--- a/.github/workflows/path_to_live_workflow.yml
+++ b/.github/workflows/path_to_live_workflow.yml
@@ -19,7 +19,11 @@ permissions:
 
 jobs:
   branch_name:
-    uses: ministryofjustice/opg-github-workflows/.github/workflows/data-parse-branch-name.yml@main
+    uses: ./.github/workflows/data-parse-branch-name.yml
+
+  build_flink:
+    name: Build Apache Flink Jar
+    uses: ./.github/workflows/apache_flink_job.yml
 
   test_lambdas:
     name: Test Lambda
@@ -68,11 +72,14 @@ jobs:
 
   terraform_environment_workflow:
     name: Terraform Environment
-    needs: ['terraform_account_workflow']
+    needs: ['terraform_account_workflow', 'build_flink']
     uses: ./.github/workflows/terraform_plan_job.yml
     with:
       terraform_path: 'terraform/environment'
       workspace: development
+      download_artifact: true
+      download_artifact_name: ${{ needs.build_flink.outputs.artifact_name }}
+      download_artifact_path_name: 'kinesis-analytics-application'
     secrets:
       aws_access_key_id_actions: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
       aws_secret_access_key_actions: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}

--- a/.github/workflows/pr_workflow.yml
+++ b/.github/workflows/pr_workflow.yml
@@ -62,7 +62,7 @@ jobs:
 
   terraform_account_workflow:
     name: Terraform Account
-    needs: ['tfsec', 'docker_build_scan_push', 'build_flink']
+    needs: ['tfsec', 'docker_build_scan_push']
     uses: ./.github/workflows/terraform_plan_job.yml
     with:
       terraform_path: 'terraform/account'
@@ -73,11 +73,12 @@ jobs:
 
   terraform_environment_workflow:
     name: Terraform Environment
-    needs: ['terraform_account_workflow']
+    needs: ['terraform_account_workflow', 'build_flink']
     uses: ./.github/workflows/terraform_plan_job.yml
     with:
       terraform_path: 'terraform/environment'
       workspace: development
+      download_flink_artifact: true
     secrets:
       aws_access_key_id_actions: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
       aws_secret_access_key_actions: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}

--- a/.github/workflows/pr_workflow.yml
+++ b/.github/workflows/pr_workflow.yml
@@ -24,6 +24,9 @@ jobs:
   build_flink:
     name: Build Apache Flink Jar
     uses: ./.github/workflows/apache_flink_job.yml
+    secrets:
+      aws_access_key_id_actions: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
+      aws_secret_access_key_actions: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}
 
   test_lambdas:
     name: Test Lambda

--- a/.github/workflows/pr_workflow.yml
+++ b/.github/workflows/pr_workflow.yml
@@ -19,7 +19,8 @@ permissions:
 
 jobs:
   branch_name:
-    uses: ministryofjustice/opg-github-workflows/.github/workflows/data-parse-branch-name.yml@main
+    uses: ./.github/workflows/data-parse-branch-name.yml
+    #uses: ministryofjustice/opg-github-workflows/.github/workflows/data-parse-branch-name.yml@main
 
   build_flink:
     name: Build Apache Flink Jar

--- a/.github/workflows/pr_workflow.yml
+++ b/.github/workflows/pr_workflow.yml
@@ -21,6 +21,10 @@ jobs:
   branch_name:
     uses: ministryofjustice/opg-github-workflows/.github/workflows/data-parse-branch-name.yml@main
 
+  build_flink:
+    name: Build Apache Flink Jar
+    uses: ./.github/workflows/apache_flink_job.yml
+
   test_lambdas:
     name: Test Lambda
     uses: ./.github/workflows/python_build_test_job.yml

--- a/.github/workflows/pr_workflow.yml
+++ b/.github/workflows/pr_workflow.yml
@@ -78,7 +78,9 @@ jobs:
     with:
       terraform_path: 'terraform/environment'
       workspace: development
-      download_flink_artifact: true
+      download_artifact: true
+      download_artifact_name: 'kinesis-to-timestream-app'
+      download_artifact_path_name: 'kinesis-analytics-application'
     secrets:
       aws_access_key_id_actions: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
       aws_secret_access_key_actions: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}

--- a/.github/workflows/pr_workflow.yml
+++ b/.github/workflows/pr_workflow.yml
@@ -78,7 +78,7 @@ jobs:
       terraform_path: 'terraform/environment'
       workspace: development
       download_artifact: true
-      download_artifact_name: 'kinesis-to-timestream-app'
+      download_artifact_name: ${{ needs.build_flink.outputs.artifact_name }}
       download_artifact_path_name: 'kinesis-analytics-application'
     secrets:
       aws_access_key_id_actions: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}

--- a/.github/workflows/pr_workflow.yml
+++ b/.github/workflows/pr_workflow.yml
@@ -20,7 +20,6 @@ permissions:
 jobs:
   branch_name:
     uses: ./.github/workflows/data-parse-branch-name.yml
-    #uses: ministryofjustice/opg-github-workflows/.github/workflows/data-parse-branch-name.yml@main
 
   build_flink:
     name: Build Apache Flink Jar

--- a/.github/workflows/pr_workflow.yml
+++ b/.github/workflows/pr_workflow.yml
@@ -24,9 +24,6 @@ jobs:
   build_flink:
     name: Build Apache Flink Jar
     uses: ./.github/workflows/apache_flink_job.yml
-    secrets:
-      aws_access_key_id_actions: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
-      aws_secret_access_key_actions: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}
 
   test_lambdas:
     name: Test Lambda
@@ -64,7 +61,7 @@ jobs:
 
   terraform_account_workflow:
     name: Terraform Account
-    needs: ['tfsec', 'docker_build_scan_push']
+    needs: ['tfsec', 'docker_build_scan_push', 'build_flink']
     uses: ./.github/workflows/terraform_plan_job.yml
     with:
       terraform_path: 'terraform/account'

--- a/.github/workflows/terraform_plan_job.yml
+++ b/.github/workflows/terraform_plan_job.yml
@@ -9,6 +9,11 @@ on:
         description: 'Terraform workspace'
         required: true
         type: string
+      download_flink_artifact:
+        description: 'Download Apache Flink Artifact'
+        default: false
+        required: false
+        type: boolean
     secrets:
       aws_access_key_id_actions:
         required: true
@@ -23,6 +28,7 @@ jobs:
         with:
           fetch-depth: '0'
       - name: Download Apache Flink Jar
+        if: ${{ inputs.download_flink_artifact == true }}
         id: download
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/terraform_plan_job.yml
+++ b/.github/workflows/terraform_plan_job.yml
@@ -9,11 +9,19 @@ on:
         description: 'Terraform workspace'
         required: true
         type: string
-      download_flink_artifact:
-        description: 'Download Apache Flink Artifact'
-        default: false
+      download_artifact:
+        description: 'Download Artifact'
         required: false
+        default: false
         type: boolean
+      download_artifact_name:
+        description: 'Artifact name'
+        required: false
+        type: string
+      download_artifact_path_name:
+        description: 'Local artifact path location'
+        required: false
+        type: string
     secrets:
       aws_access_key_id_actions:
         required: true
@@ -27,13 +35,13 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: '0'
-      - name: Download Apache Flink Jar
-        if: ${{ inputs.download_flink_artifact == true }}
+      - name: Download Artifact
+        if: ${{ inputs.download_artifact == true }}
         id: download
         uses: actions/download-artifact@v3
         with:
-          name: kinesis-to-timestream-app
-          path: kinesis-analytics-application
+          name: ${{ inputs.download_artifact_name }}
+          path: ${{ inputs.download_artifact_path_name }}
       - uses: unfor19/install-aws-cli-action@v1
       - uses: hashicorp/setup-terraform@v1
         with:

--- a/.github/workflows/terraform_plan_job.yml
+++ b/.github/workflows/terraform_plan_job.yml
@@ -22,6 +22,12 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: '0'
+      - name: Download Apache Flink Jar
+        id: download
+        uses: actions/upload-artifact@v3
+        with:
+          name: kinesis-to-timestream-app
+          path: kinesis-analytics-application
       - uses: unfor19/install-aws-cli-action@v1
       - uses: hashicorp/setup-terraform@v1
         with:

--- a/.github/workflows/terraform_plan_job.yml
+++ b/.github/workflows/terraform_plan_job.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Download Apache Flink Jar
         if: ${{ inputs.download_flink_artifact == true }}
         id: download
-        uses: actions/upload-artifact@v3
+        uses: actions/download-artifact@v3
         with:
           name: kinesis-to-timestream-app
           path: kinesis-analytics-application

--- a/.github/workflows/terraform_plan_job.yml
+++ b/.github/workflows/terraform_plan_job.yml
@@ -68,6 +68,7 @@ jobs:
       - name: Terraform Plan
         env:
           TF_WORKSPACE: ${{ inputs.workspace }}
+          TF_VAR_timestream_artifact_name: ${{ inputs.download_artifact_name }}
         run: |
           terraform workspace show
           terraform plan -input=false -parallelism=30
@@ -76,6 +77,7 @@ jobs:
       - name: Terraform Apply Environment
         env:
           TF_WORKSPACE: ${{ inputs.workspace }}
+          TF_VAR_timestream_artifact_name: ${{ inputs.download_artifact_name }}
         if: github.ref == 'refs/heads/main'
         run: |
           terraform apply -lock-timeout=300s -input=false -auto-approve -parallelism=30

--- a/terraform/environment/kinesis-data-analytics.tf
+++ b/terraform/environment/kinesis-data-analytics.tf
@@ -5,7 +5,7 @@ resource "aws_s3_bucket" "flink" {
 resource "aws_s3_bucket_object" "flink" {
   bucket = aws_s3_bucket.flink.bucket
   key    = var.flink_name
-  source = "../../kinesis-analytics-application/sample-kinesis-to-timestream-app-0.1-SNAPSHOT.jar"
+  source = "../../kinesis-analytics-application/opg-metrics-kinesis-to-timestream-app.jar"
 }
 
 resource "aws_cloudwatch_log_group" "flink" {

--- a/terraform/environment/kinesis-data-analytics.tf
+++ b/terraform/environment/kinesis-data-analytics.tf
@@ -1,7 +1,7 @@
 resource "aws_s3_bucket" "flink" {
   bucket = var.flink_name
 }
-# http data source https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http
+
 resource "aws_s3_bucket_object" "flink" {
   bucket = aws_s3_bucket.flink.bucket
   key    = var.flink_name

--- a/terraform/environment/kinesis-data-analytics.tf
+++ b/terraform/environment/kinesis-data-analytics.tf
@@ -2,10 +2,14 @@ resource "aws_s3_bucket" "flink" {
   bucket = var.flink_name
 }
 
+variable "timestream_artifact_name" {
+  type = string
+}
+
 resource "aws_s3_bucket_object" "flink" {
   bucket = aws_s3_bucket.flink.bucket
   key    = var.flink_name
-  source = "../../kinesis-analytics-application/opg-metrics-kinesis-to-timestream-app.jar"
+  source = "../../kinesis-analytics-application/${var.timestream_artifact_name}.jar"
 }
 
 resource "aws_cloudwatch_log_group" "flink" {

--- a/terraform/environment/kinesis-data-analytics.tf
+++ b/terraform/environment/kinesis-data-analytics.tf
@@ -1,11 +1,11 @@
 resource "aws_s3_bucket" "flink" {
   bucket = var.flink_name
 }
-
+# http data source https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http
 resource "aws_s3_bucket_object" "flink" {
   bucket = aws_s3_bucket.flink.bucket
   key    = var.flink_name
-  source = "../../kinesis-analytics-application/timestreamsink-1.0-SNAPSHOT.jar"
+  source = "../../kinesis-analytics-application/sample-kinesis-to-timestream-app-0.1-SNAPSHOT.jar"
 }
 
 resource "aws_cloudwatch_log_group" "flink" {


### PR DESCRIPTION
# Purpose

Removes the precompiled Apache Flink Kinesis to Timestream Jar and builds the latest version in CI to ensure we always have the latest version.

Fixes Ticket: MET-49

## Approach

A dedicated job checkouts and builds the artifact which will then on a plan and apply for environment will download and reference this .jar file.

## Checklist

* [x] I have performed a self-review of my own code
