### PR TITLE
Add `setup-terraform` to rotate api workflow

### DIFF
--- a/.github/workflows/rotate_api_keys_workflow.yml
+++ b/.github/workflows/rotate_api_keys_workflow.yml
@@ -11,6 +11,9 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 2
+      - uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: 1.2.3
       - name: Terraform Init
         run: terraform init -input=false
         working-directory: ./terraform/environment
@@ -34,6 +37,9 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 2
+      - uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: 1.2.3
       - name: Terraform Init
         run: terraform init -input=false
         working-directory: ./terraform/environment


### PR DESCRIPTION
# Purpose

The nightly rotate key workflow currently breaks. This seems to be caused by not setting up terraform correctly as a step in the jobs.

https://github.com/ministryofjustice/opg-metrics/runs/7532681536?check_suite_focus=true

## Approach

Add in the `hashicorp/setup-terraform` step specifying the version `1.2.3`.

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [x] I have added tests to prove my work
* [ ] The product team have tested these changes
