### PR TITLE
Taint workflow fix - Add missing `TF_VAR_timestream_artifact_name`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    pull-request-branch-name:
+      separator: "-"
+    directory: '/'
+    schedule:
+      interval: 'daily'

--- a/.github/workflows/rotate_api_keys_workflow.yml
+++ b/.github/workflows/rotate_api_keys_workflow.yml
@@ -80,5 +80,5 @@ jobs:
           TF_WORKSPACE: development
           TF_VAR_timestream_artifact_name: opg-metrics-kinesis-to-timestream-app
         run: |
-          terraform apply | ~/home/runner/work/opg-metrics/opg-metrics/scripts/pipeline/redact_output.sh
+          terraform apply | ~/work/opg-metrics/opg-metrics/scripts/pipeline/redact_output.sh
         working-directory: ./terraform/environment

--- a/.github/workflows/rotate_api_keys_workflow.yml
+++ b/.github/workflows/rotate_api_keys_workflow.yml
@@ -1,7 +1,6 @@
 on:
-  pull_request:
-    branches:
-      - main
+  schedule:
+    - cron: '0 2 * * *' # Every 2 a.m.
 
 jobs:
   taint_api_keys:

--- a/.github/workflows/rotate_api_keys_workflow.yml
+++ b/.github/workflows/rotate_api_keys_workflow.yml
@@ -1,6 +1,7 @@
 on:
-  schedule:
-    - cron: '0 2 * * *' # Every 2 a.m.
+  pull_request:
+    branches:
+      - main
 
 jobs:
   taint_api_keys:

--- a/.github/workflows/rotate_api_keys_workflow.yml
+++ b/.github/workflows/rotate_api_keys_workflow.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Terraform taint api keys
         env:
           TF_WORKSPACE: development
+          TF_VAR_timestream_artifact_name: opg-metrics-kinesis-to-timestream-app
         run: |
           all_aws_access_keys=$(terraform state list | grep aws_api_gateway_api_key | sed 's/*//g')
           for access_key in $all_aws_access_keys
@@ -76,6 +77,7 @@ jobs:
       - name: Terraform replace api keys
         env:
           TF_WORKSPACE: development
+          TF_VAR_timestream_artifact_name: opg-metrics-kinesis-to-timestream-app
         run: |
           terraform apply | ~/project/scripts/pipeline/redact_output.sh
         working-directory: ./terraform/environment

--- a/.github/workflows/rotate_api_keys_workflow.yml
+++ b/.github/workflows/rotate_api_keys_workflow.yml
@@ -14,9 +14,10 @@ jobs:
 
       - uses: unfor19/install-aws-cli-action@v1
 
-      - uses: hashicorp/setup-terraform@v1
+      - uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: 1.2.3
+          terraform_wrapper: false
 
       - name: Configure AWS Credentials For Terraform
         uses: aws-actions/configure-aws-credentials@v1
@@ -54,9 +55,10 @@ jobs:
 
       - uses: unfor19/install-aws-cli-action@v1
 
-      - uses: hashicorp/setup-terraform@v1
+      - uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: 1.2.3
+          terraform_wrapper: false
 
       - name: Configure AWS Credentials For Terraform
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/rotate_api_keys_workflow.yml
+++ b/.github/workflows/rotate_api_keys_workflow.yml
@@ -80,5 +80,5 @@ jobs:
           TF_WORKSPACE: development
           TF_VAR_timestream_artifact_name: opg-metrics-kinesis-to-timestream-app
         run: |
-          terraform apply | ~/project/scripts/pipeline/redact_output.sh
+          terraform apply | ~/home/runner/work/opg-metrics/opg-metrics/scripts/pipeline/redact_output.sh
         working-directory: ./terraform/environment

--- a/.github/workflows/terraform_plan_job.yml
+++ b/.github/workflows/terraform_plan_job.yml
@@ -42,10 +42,14 @@ jobs:
         with:
           name: ${{ inputs.download_artifact_name }}
           path: ${{ inputs.download_artifact_path_name }}
+
       - uses: unfor19/install-aws-cli-action@v1
-      - uses: hashicorp/setup-terraform@v1
+
+      - uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: 1.2.3
+          terraform_wrapper: false
+
       - name: Configure AWS Credentials For Terraform
         uses: aws-actions/configure-aws-credentials@v1
         with:


### PR DESCRIPTION
# Purpose

Upgrade `hashicorp/setup-terraform` github action and disabled stdout messages in TF.

Pass a missing TF variable `TF_VAR_timestream_artifact_name` to the taint jobs so no missing variable errors occur in TF.

If this works successfully then we need to look at whether we build the jar file in this workflow and get the name from it each time or whether we are happy with the string being passed as in this PR.

Also adds in a missing dependabot configuration for github actions

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
