### PR TITLE
MET-58 Update swagger-ui and checkout action

### DIFF
--- a/.github/workflows/openapi_ui.yaml
+++ b/.github/workflows/openapi_ui.yaml
@@ -5,6 +5,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   # Set the job key. The key is displayed as the job name
@@ -17,10 +20,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Generate Swagger UI
-        uses: Legion2/swagger-ui-action@v1.0.2
+        uses: Legion2/swagger-ui-action@v1
         with:
           output: swagger-ui
           spec-file: terraform/environment/api/openapi_spec.yaml

--- a/.github/workflows/openapi_ui.yaml
+++ b/.github/workflows/openapi_ui.yaml
@@ -5,9 +5,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
 
 jobs:
   # Set the job key. The key is displayed as the job name


### PR DESCRIPTION
Fixes #61

# Purpose

The swagger ui job has been consistently failing for the last few weeks. This fixes the issue by upgrading the action that runs it.

Failures here: https://github.com/ministryofjustice/opg-metrics/actions/workflows/openapi_ui.yaml

Fixes Ticket: MET-58

## Approach

Update the Github Action for checkout and swagger-ui to the latest versions.

Tested by running the workflow on a PR build to see if it passed successfully.

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
