### PR TITLE
Create service access for Sirius dev account

### DIFF
--- a/terraform/environment/api-keys.tf
+++ b/terraform/environment/api-keys.tf
@@ -33,3 +33,15 @@ module "trusted_service_access_costs_to_metrics_development" {
     "arn:aws:iam::311462405659:root"
   ]
 }
+  
+module "trusted_service_access_sirius_development" {
+  trusted_service_name               = "sirius-development"
+  source                             = "../modules/trusted_service_access"
+  aws_api_gateway_rest_api           = aws_api_gateway_rest_api.kinesis_stream_api_gateway.id
+  aws_api_gateway_stage              = aws_api_gateway_stage.kinesis_stream_api_gateway.stage_name
+  secret_recovery_window_in_days     = 0
+  secretsmanager_api_keys_kms_key_id = aws_kms_key.api_key.key_id
+  identifiers_arns = [
+    "arn:aws:iam::288342028542:root"
+  ]
+}


### PR DESCRIPTION
# Purpose

So we can start sharing case status metrics

Fixes Ticket: VEGA-1377

## Approach

Copied the block above

## Learning

I've looked at how the `trusted_service_access` module works

## Checklist

* [X] I have performed a self-review of my own code
* [x] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
  * N/A
* [X] I have added tests to prove my work
  * N/A
* [X] The product team have tested these changes
  * N/A
