### PR TITLE
Allow Sirius dev to decrypt KMS key

### DIFF
--- a/terraform/environment/kms.tf
+++ b/terraform/environment/kms.tf
@@ -40,7 +40,8 @@ data "aws_iam_policy_document" "api_key_kms" {
       type = "AWS"
       identifiers = [
         "arn:aws:iam::367815980639:root",
-        "arn:aws:iam::311462405659:root"
+        "arn:aws:iam::311462405659:root",
+        "arn:aws:iam::288342028542:root"
       ]
     }
   }


### PR DESCRIPTION
# Purpose

Allow Sirius dev to decrypt KMS key so that it can access its secret for authentication

Supports Ticket: VEGA-1377

## Approach

Again, following patterns of those before

## Learning

N/A

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [x] I have added tests to prove my work
* [x] The product team have tested these changes
