### PR TITLE
Add API keys for all Sirius environments

### DIFF
--- a/terraform/environment/api-keys.tf
+++ b/terraform/environment/api-keys.tf
@@ -33,7 +33,7 @@ module "trusted_service_access_costs_to_metrics_development" {
     "arn:aws:iam::311462405659:root"
   ]
 }
-  
+
 module "trusted_service_access_sirius_development" {
   trusted_service_name               = "sirius-development"
   source                             = "../modules/trusted_service_access"
@@ -43,5 +43,31 @@ module "trusted_service_access_sirius_development" {
   secretsmanager_api_keys_kms_key_id = aws_kms_key.api_key.key_id
   identifiers_arns = [
     "arn:aws:iam::288342028542:root"
+  ]
+}
+
+module "trusted_service_access_sirius_preproduction" {
+  trusted_service_name               = "sirius-preproduction"
+  source                             = "../modules/trusted_service_access"
+  aws_api_gateway_rest_api           = aws_api_gateway_rest_api.kinesis_stream_api_gateway.id
+  aws_api_gateway_stage              = aws_api_gateway_stage.kinesis_stream_api_gateway.stage_name
+  secret_recovery_window_in_days     = 0
+  secretsmanager_api_keys_kms_key_id = aws_kms_key.api_key.key_id
+  identifiers_arns = [
+    "arn:aws:iam::492687888235:api-ecs-preproduction-20200204165900331400000008",
+    "arn:aws:iam::492687888235:api-ecs-preproduction-2021040714392497160000000a"
+  ]
+}
+
+module "trusted_service_access_sirius_production" {
+  trusted_service_name               = "sirius-production"
+  source                             = "../modules/trusted_service_access"
+  aws_api_gateway_rest_api           = aws_api_gateway_rest_api.kinesis_stream_api_gateway.id
+  aws_api_gateway_stage              = aws_api_gateway_stage.kinesis_stream_api_gateway.stage_name
+  secret_recovery_window_in_days     = 0
+  secretsmanager_api_keys_kms_key_id = aws_kms_key.api_key.key_id
+  identifiers_arns = [
+    "arn:aws:iam::649098267436:api-ecs-production-20190802114727697300000001",
+    "arn:aws:iam::649098267436:api-ecs-production-2021080908515105620000000a"
   ]
 }

--- a/terraform/environment/kms.tf
+++ b/terraform/environment/kms.tf
@@ -41,7 +41,11 @@ data "aws_iam_policy_document" "api_key_kms" {
       identifiers = [
         "arn:aws:iam::367815980639:root",
         "arn:aws:iam::311462405659:root",
-        "arn:aws:iam::288342028542:root"
+        "arn:aws:iam::288342028542:root",
+        "arn:aws:iam::492687888235:api-ecs-preproduction-20200204165900331400000008",
+        "arn:aws:iam::492687888235:api-ecs-preproduction-2021040714392497160000000a",
+        "arn:aws:iam::649098267436:api-ecs-production-20190802114727697300000001",
+        "arn:aws:iam::649098267436:api-ecs-production-2021080908515105620000000a"
       ]
     }
   }


### PR DESCRIPTION
# Purpose

Give each account its own key and all have access permissions

Fixes Ticket: VEGA-1377

## Approach

Giving each account a separate key for some permission isolation.

## Learning

N/A

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
  * N/A
* [x] I have added tests to prove my work
  * N/A
* [x] The product team have tested these changes
  * N/A
