### PR TITLE
Fix typo in role ARNs

### DIFF
--- a/terraform/environment/api-keys.tf
+++ b/terraform/environment/api-keys.tf
@@ -54,8 +54,8 @@ module "trusted_service_access_sirius_preproduction" {
   secret_recovery_window_in_days     = 0
   secretsmanager_api_keys_kms_key_id = aws_kms_key.api_key.key_id
   identifiers_arns = [
-    "arn:aws:iam::492687888235:api-ecs-preproduction-20200204165900331400000008",
-    "arn:aws:iam::492687888235:api-ecs-preproduction-2021040714392497160000000a"
+    "arn:aws:iam::492687888235:role/api-ecs-preproduction-20200204165900331400000008",
+    "arn:aws:iam::492687888235:role/api-ecs-preproduction-2021040714392497160000000a"
   ]
 }
 
@@ -67,7 +67,7 @@ module "trusted_service_access_sirius_production" {
   secret_recovery_window_in_days     = 0
   secretsmanager_api_keys_kms_key_id = aws_kms_key.api_key.key_id
   identifiers_arns = [
-    "arn:aws:iam::649098267436:api-ecs-production-20190802114727697300000001",
-    "arn:aws:iam::649098267436:api-ecs-production-2021080908515105620000000a"
+    "arn:aws:iam::649098267436:role/api-ecs-production-20190802114727697300000001",
+    "arn:aws:iam::649098267436:role/api-ecs-production-2021080908515105620000000a"
   ]
 }

--- a/terraform/environment/kms.tf
+++ b/terraform/environment/kms.tf
@@ -42,10 +42,10 @@ data "aws_iam_policy_document" "api_key_kms" {
         "arn:aws:iam::367815980639:root",
         "arn:aws:iam::311462405659:root",
         "arn:aws:iam::288342028542:root",
-        "arn:aws:iam::492687888235:api-ecs-preproduction-20200204165900331400000008",
-        "arn:aws:iam::492687888235:api-ecs-preproduction-2021040714392497160000000a",
-        "arn:aws:iam::649098267436:api-ecs-production-20190802114727697300000001",
-        "arn:aws:iam::649098267436:api-ecs-production-2021080908515105620000000a"
+        "arn:aws:iam::492687888235:role/api-ecs-preproduction-20200204165900331400000008",
+        "arn:aws:iam::492687888235:role/api-ecs-preproduction-2021040714392497160000000a",
+        "arn:aws:iam::649098267436:role/api-ecs-production-20190802114727697300000001",
+        "arn:aws:iam::649098267436:role/api-ecs-production-2021080908515105620000000a"
       ]
     }
   }


### PR DESCRIPTION
# Purpose

Fix typo in role ARNs. They were missing the `role/` prefix

Fixes Ticket: VEGA-1377

## Approach

Discovered during deployment

## Learning

Role ARNs have a `role/` prefix to their name part

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
