### PR TITLE
SP-1211 - Add API keys for shared prod and dev accounts #minor

### DIFF
--- a/terraform/environment/api-keys.tf
+++ b/terraform/environment/api-keys.tf
@@ -72,8 +72,8 @@ module "trusted_service_access_sirius_production" {
   ]
 }
 
-module "trusted_service_access_shared_development" {
-  trusted_service_name               = "shared-development"
+module "trusted_service_access_jenkins_development" {
+  trusted_service_name               = "jenkins-development"
   source                             = "../modules/trusted_service_access"
   aws_api_gateway_rest_api           = aws_api_gateway_rest_api.kinesis_stream_api_gateway.id
   aws_api_gateway_stage              = aws_api_gateway_stage.kinesis_stream_api_gateway.stage_name
@@ -84,8 +84,8 @@ module "trusted_service_access_shared_development" {
   ]
 }
 
-module "trusted_service_access_shared_production" {
-  trusted_service_name               = "shared-production"
+module "trusted_service_access_jenkins_production" {
+  trusted_service_name               = "jenkins-production"
   source                             = "../modules/trusted_service_access"
   aws_api_gateway_rest_api           = aws_api_gateway_rest_api.kinesis_stream_api_gateway.id
   aws_api_gateway_stage              = aws_api_gateway_stage.kinesis_stream_api_gateway.stage_name

--- a/terraform/environment/api-keys.tf
+++ b/terraform/environment/api-keys.tf
@@ -80,7 +80,7 @@ module "trusted_service_access_jenkins_development" {
   secret_recovery_window_in_days     = 0
   secretsmanager_api_keys_kms_key_id = aws_kms_key.api_key.key_id
   identifiers_arns = [
-    "arn:aws:iam::679638075911:root"
+    "arn:aws:iam::679638075911:role/jenkins-primary-20190425141320485900000006"
   ]
 }
 
@@ -92,6 +92,6 @@ module "trusted_service_access_jenkins_production" {
   secret_recovery_window_in_days     = 0
   secretsmanager_api_keys_kms_key_id = aws_kms_key.api_key.key_id
   identifiers_arns = [
-    "arn:aws:iam::997462338508:root"
+    "arn:aws:iam::997462338508:role/jenkins-primary-20190430083911121200000007"
   ]
 }

--- a/terraform/environment/api-keys.tf
+++ b/terraform/environment/api-keys.tf
@@ -71,3 +71,27 @@ module "trusted_service_access_sirius_production" {
     "arn:aws:iam::649098267436:role/api-ecs-production-2021080908515105620000000a"
   ]
 }
+
+module "trusted_service_access_shared_development" {
+  trusted_service_name               = "shared-development"
+  source                             = "../modules/trusted_service_access"
+  aws_api_gateway_rest_api           = aws_api_gateway_rest_api.kinesis_stream_api_gateway.id
+  aws_api_gateway_stage              = aws_api_gateway_stage.kinesis_stream_api_gateway.stage_name
+  secret_recovery_window_in_days     = 0
+  secretsmanager_api_keys_kms_key_id = aws_kms_key.api_key.key_id
+  identifiers_arns = [
+    "arn:aws:iam::679638075911:root"
+  ]
+}
+
+module "trusted_service_access_shared_production" {
+  trusted_service_name               = "shared-production"
+  source                             = "../modules/trusted_service_access"
+  aws_api_gateway_rest_api           = aws_api_gateway_rest_api.kinesis_stream_api_gateway.id
+  aws_api_gateway_stage              = aws_api_gateway_stage.kinesis_stream_api_gateway.stage_name
+  secret_recovery_window_in_days     = 0
+  secretsmanager_api_keys_kms_key_id = aws_kms_key.api_key.key_id
+  identifiers_arns = [
+    "arn:aws:iam::997462338508:root"
+  ]
+}

--- a/terraform/environment/kms.tf
+++ b/terraform/environment/kms.tf
@@ -42,12 +42,12 @@ data "aws_iam_policy_document" "api_key_kms" {
         "arn:aws:iam::367815980639:root",
         "arn:aws:iam::311462405659:root",
         "arn:aws:iam::288342028542:root",
-        "arn:aws:iam::679638075911:root",
-        "arn:aws:iam::997462338508:root",
         "arn:aws:iam::492687888235:role/api-ecs-preproduction-20200204165900331400000008",
         "arn:aws:iam::492687888235:role/api-ecs-preproduction-2021040714392497160000000a",
         "arn:aws:iam::649098267436:role/api-ecs-production-20190802114727697300000001",
-        "arn:aws:iam::649098267436:role/api-ecs-production-2021080908515105620000000a"
+        "arn:aws:iam::649098267436:role/api-ecs-production-2021080908515105620000000a",
+        "arn:aws:iam::679638075911:role/jenkins-primary-20190425141320485900000006",
+        "arn:aws:iam::997462338508:role/jenkins-primary-20190430083911121200000007"
       ]
     }
   }

--- a/terraform/environment/kms.tf
+++ b/terraform/environment/kms.tf
@@ -42,6 +42,8 @@ data "aws_iam_policy_document" "api_key_kms" {
         "arn:aws:iam::367815980639:root",
         "arn:aws:iam::311462405659:root",
         "arn:aws:iam::288342028542:root",
+        "arn:aws:iam::679638075911:root",
+        "arn:aws:iam::997462338508:root",
         "arn:aws:iam::492687888235:role/api-ecs-preproduction-20200204165900331400000008",
         "arn:aws:iam::492687888235:role/api-ecs-preproduction-2021040714392497160000000a",
         "arn:aws:iam::649098267436:role/api-ecs-production-20190802114727697300000001",


### PR DESCRIPTION
# Purpose

To send metrics from jenkins which the infra for lives in the shared accounts

Fixes Ticket: SP-1211

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
