### PR TITLE
Update docker lambda python image

### DIFF
--- a/.github/workflows/docker_job.yml
+++ b/.github/workflows/docker_job.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Trivy Image Vulnerability Scanner
         id: trivy_scan
-        uses: aquasecurity/trivy-action@0.3.0
+        uses: aquasecurity/trivy-action@0.8.0
         with:
           image-ref: ${{ matrix.lambda_name }}:latest
           severity: 'HIGH,CRITICAL'

--- a/lambda/clsf-to-sqs/Dockerfile
+++ b/lambda/clsf-to-sqs/Dockerfile
@@ -23,9 +23,9 @@ ARG FUNCTION_DIR
 RUN mkdir -p ${FUNCTION_DIR}
 
 # Copy function code
-COPY src/main.py ${FUNCTION_DIR}
+COPY lambda/clsf-to-sqs/src/main.py ${FUNCTION_DIR}
 
-COPY src/requirements.txt requirements.txt
+COPY lambda/clsf-to-sqs/src/requirements.txt requirements.txt
 
 # Install the runtime interface client
 RUN python -m pip install --upgrade pip

--- a/lambda/clsf-to-sqs/Dockerfile
+++ b/lambda/clsf-to-sqs/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/python:3.8
+FROM public.ecr.aws/lambda/python:3.9.2022.12.14.07
 
 WORKDIR /var/task
 COPY lambda/clsf-to-sqs/src/main.py ./

--- a/lambda/clsf-to-sqs/Dockerfile
+++ b/lambda/clsf-to-sqs/Dockerfile
@@ -1,5 +1,48 @@
-FROM public.ecr.aws/lambda/python:3.9.2022.12.14.07
+# Define function directory
+ARG FUNCTION_DIR="/function"
 
-WORKDIR /var/task
-COPY lambda/clsf-to-sqs/src/main.py ./
-CMD ["main.handler"]
+FROM python:alpine AS python-alpine
+RUN apk add --no-cache \
+    libstdc++
+
+FROM python-alpine as build-image
+
+# Install aws-lambda-cpp build dependencies
+RUN apk add --no-cache \
+    build-base \
+    libtool \
+    autoconf \
+    automake \
+    make \
+    cmake \
+    libcurl
+
+# Include global arg in this stage of the build
+ARG FUNCTION_DIR
+# Create function directory
+RUN mkdir -p ${FUNCTION_DIR}
+
+# Copy function code
+COPY src/main.py ${FUNCTION_DIR}
+
+COPY src/requirements.txt requirements.txt
+
+# Install the runtime interface client
+RUN python -m pip install --upgrade pip
+RUN python -m pip install \
+        --target ${FUNCTION_DIR} \
+        --requirement requirements.txt
+
+# Multi-stage build: grab a fresh copy of the base image
+FROM python-alpine
+
+# Include global arg in this stage of the build
+ARG FUNCTION_DIR
+# Set working directory to function root directory
+WORKDIR ${FUNCTION_DIR}
+
+# Copy in the build image dependencies
+COPY --from=build-image ${FUNCTION_DIR} ${FUNCTION_DIR}
+
+ENTRYPOINT [ "/usr/local/bin/python", "-m", "awslambdaric" ]
+CMD [ "send_health_events_to_slack.lambda_handler" ]

--- a/lambda/clsf-to-sqs/Dockerfile
+++ b/lambda/clsf-to-sqs/Dockerfile
@@ -1,7 +1,7 @@
 # Define function directory
 ARG FUNCTION_DIR="/function"
 
-FROM python:alpine AS python-alpine
+FROM python:alpine3.16 AS python-alpine
 RUN apk add --no-cache \
     libstdc++
 
@@ -13,6 +13,7 @@ RUN apk add --no-cache \
     libtool \
     autoconf \
     automake \
+    libexecinfo-dev \
     make \
     cmake \
     libcurl

--- a/lambda/clsf-to-sqs/Dockerfile
+++ b/lambda/clsf-to-sqs/Dockerfile
@@ -45,4 +45,4 @@ WORKDIR ${FUNCTION_DIR}
 COPY --from=build-image ${FUNCTION_DIR} ${FUNCTION_DIR}
 
 ENTRYPOINT [ "/usr/local/bin/python", "-m", "awslambdaric" ]
-CMD [ "send_health_events_to_slack.lambda_handler" ]
+CMD ["main.handler"]

--- a/lambda/clsf-to-sqs/Test.Dockerfile
+++ b/lambda/clsf-to-sqs/Test.Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/python:3.8
+FROM public.ecr.aws/lambda/python:3.9.2022.12.14.07
 
 RUN pip install requests requests_aws4auth
 

--- a/lambda/clsf-to-sqs/Test.Dockerfile
+++ b/lambda/clsf-to-sqs/Test.Dockerfile
@@ -1,7 +1,49 @@
-FROM public.ecr.aws/lambda/python:3.9.2022.12.14.07
+# Define function directory
+ARG FUNCTION_DIR="/function"
 
-RUN pip install requests requests_aws4auth
+FROM python:alpine AS python-alpine
+RUN apk add --no-cache \
+    libstdc++
 
-WORKDIR /var/task
-COPY . ./
-CMD ["main.handler"]
+FROM python-alpine as build-image
+
+# Install aws-lambda-cpp build dependencies
+RUN apk add --no-cache \
+    build-base \
+    libtool \
+    autoconf \
+    automake \
+    make \
+    cmake \
+    libcurl
+
+# Include global arg in this stage of the build
+ARG FUNCTION_DIR
+# Create function directory
+RUN mkdir -p ${FUNCTION_DIR}
+
+# Copy function code
+COPY src/test_main.py ${FUNCTION_DIR}
+COPY src/main.py ${FUNCTION_DIR}
+
+COPY src/requirements_dev.txt requirements.txt
+
+# Install the runtime interface client
+RUN python -m pip install --upgrade pip
+RUN python -m pip install \
+        --target ${FUNCTION_DIR} \
+        --requirement requirements.txt
+
+# Multi-stage build: grab a fresh copy of the base image
+FROM python-alpine
+
+# Include global arg in this stage of the build
+ARG FUNCTION_DIR
+# Set working directory to function root directory
+WORKDIR ${FUNCTION_DIR}
+
+# Copy in the build image dependencies
+COPY --from=build-image ${FUNCTION_DIR} ${FUNCTION_DIR}
+
+ENTRYPOINT [ "/usr/local/bin/python", "-m", "awslambdaric" ]
+CMD [ "send_health_events_to_slack.lambda_handler" ]

--- a/lambda/clsf-to-sqs/Test.Dockerfile
+++ b/lambda/clsf-to-sqs/Test.Dockerfile
@@ -46,4 +46,4 @@ WORKDIR ${FUNCTION_DIR}
 COPY --from=build-image ${FUNCTION_DIR} ${FUNCTION_DIR}
 
 ENTRYPOINT [ "/usr/local/bin/python", "-m", "awslambdaric" ]
-CMD [ "send_health_events_to_slack.lambda_handler" ]
+CMD ["main.handler"]

--- a/lambda/clsf-to-sqs/Test.Dockerfile
+++ b/lambda/clsf-to-sqs/Test.Dockerfile
@@ -1,7 +1,7 @@
 # Define function directory
 ARG FUNCTION_DIR="/function"
 
-FROM python:alpine AS python-alpine
+FROM python:alpine3.16 AS python-alpine
 RUN apk add --no-cache \
     libstdc++
 
@@ -13,6 +13,7 @@ RUN apk add --no-cache \
     libtool \
     autoconf \
     automake \
+    libexecinfo-dev \
     make \
     cmake \
     libcurl

--- a/lambda/clsf-to-sqs/src/requirements.txt
+++ b/lambda/clsf-to-sqs/src/requirements.txt
@@ -1,0 +1,3 @@
+requests==2.28.1
+boto3==1.26.34
+requests_aws4auth==1.1.2

--- a/lambda/clsf-to-sqs/src/requirements.txt
+++ b/lambda/clsf-to-sqs/src/requirements.txt
@@ -1,3 +1,4 @@
 requests==2.28.1
 boto3==1.26.34
 requests_aws4auth==1.1.2
+awslambdaric==2.0.4

--- a/lambda/clsf-to-sqs/src/requirements_dev.txt
+++ b/lambda/clsf-to-sqs/src/requirements_dev.txt
@@ -2,3 +2,4 @@ moto[sqs]==4.0.12
 coverage==7.0.0
 pylint==2.15.9
 pytest==7.2.0
+awslambdaric==2.0.4

--- a/lambda/clsf-to-sqs/src/requirements_dev.txt
+++ b/lambda/clsf-to-sqs/src/requirements_dev.txt
@@ -1,4 +1,4 @@
-moto[sqs]==2.3.0
-coverage==6.2
-pylint==2.12.2
-pytest==6.2.5
+moto[sqs]==4.0.12
+coverage==7.0.0
+pylint==2.15.9
+pytest==7.2.0

--- a/lambda/ship-to-opg-metrics/Dockerfile
+++ b/lambda/ship-to-opg-metrics/Dockerfile
@@ -23,9 +23,9 @@ ARG FUNCTION_DIR
 RUN mkdir -p ${FUNCTION_DIR}
 
 # Copy function code
-COPY src/main.py ${FUNCTION_DIR}
+COPY lambda/clsf-to-sqs/src/main.py ${FUNCTION_DIR}
 
-COPY src/requirements.txt requirements.txt
+COPY lambda/clsf-to-sqs/src/requirements.txt requirements.txt
 
 # Install the runtime interface client
 RUN python -m pip install --upgrade pip

--- a/lambda/ship-to-opg-metrics/Dockerfile
+++ b/lambda/ship-to-opg-metrics/Dockerfile
@@ -1,7 +1,7 @@
 # Define function directory
 ARG FUNCTION_DIR="/function"
 
-FROM python:alpine AS python-alpine
+FROM python:alpine3.16 AS python-alpine
 RUN apk add --no-cache \
     libstdc++
 
@@ -13,6 +13,7 @@ RUN apk add --no-cache \
     libtool \
     autoconf \
     automake \
+    libexecinfo-dev \
     make \
     cmake \
     libcurl

--- a/lambda/ship-to-opg-metrics/Dockerfile
+++ b/lambda/ship-to-opg-metrics/Dockerfile
@@ -45,4 +45,4 @@ WORKDIR ${FUNCTION_DIR}
 COPY --from=build-image ${FUNCTION_DIR} ${FUNCTION_DIR}
 
 ENTRYPOINT [ "/usr/local/bin/python", "-m", "awslambdaric" ]
-CMD [ "send_health_events_to_slack.lambda_handler" ]
+CMD ["main.handler"]

--- a/lambda/ship-to-opg-metrics/Dockerfile
+++ b/lambda/ship-to-opg-metrics/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/python:3.8
+FROM public.ecr.aws/lambda/python:3.9.2022.12.14.07
 
 WORKDIR /var/task
 

--- a/lambda/ship-to-opg-metrics/Dockerfile
+++ b/lambda/ship-to-opg-metrics/Dockerfile
@@ -1,9 +1,48 @@
-FROM public.ecr.aws/lambda/python:3.9.2022.12.14.07
+# Define function directory
+ARG FUNCTION_DIR="/function"
 
-WORKDIR /var/task
+FROM python:alpine AS python-alpine
+RUN apk add --no-cache \
+    libstdc++
 
-COPY lambda/ship-to-opg-metrics/src/requirements.txt ./
-COPY lambda/ship-to-opg-metrics/src/main.py ./
-RUN pip install --no-cache-dir -r ./requirements.txt
+FROM python-alpine as build-image
 
-CMD ["main.handler"]
+# Install aws-lambda-cpp build dependencies
+RUN apk add --no-cache \
+    build-base \
+    libtool \
+    autoconf \
+    automake \
+    make \
+    cmake \
+    libcurl
+
+# Include global arg in this stage of the build
+ARG FUNCTION_DIR
+# Create function directory
+RUN mkdir -p ${FUNCTION_DIR}
+
+# Copy function code
+COPY src/main.py ${FUNCTION_DIR}
+
+COPY src/requirements.txt requirements.txt
+
+# Install the runtime interface client
+RUN python -m pip install --upgrade pip
+RUN python -m pip install \
+        --target ${FUNCTION_DIR} \
+        --requirement requirements.txt
+
+# Multi-stage build: grab a fresh copy of the base image
+FROM python-alpine
+
+# Include global arg in this stage of the build
+ARG FUNCTION_DIR
+# Set working directory to function root directory
+WORKDIR ${FUNCTION_DIR}
+
+# Copy in the build image dependencies
+COPY --from=build-image ${FUNCTION_DIR} ${FUNCTION_DIR}
+
+ENTRYPOINT [ "/usr/local/bin/python", "-m", "awslambdaric" ]
+CMD [ "send_health_events_to_slack.lambda_handler" ]

--- a/lambda/ship-to-opg-metrics/src/requirements.txt
+++ b/lambda/ship-to-opg-metrics/src/requirements.txt
@@ -1,3 +1,3 @@
-requests
-boto3
-aws-xray-sdk==2.4.3
+requests==2.28.1
+boto3==1.26.34
+aws-xray-sdk==2.11.0

--- a/lambda/ship-to-opg-metrics/src/requirements.txt
+++ b/lambda/ship-to-opg-metrics/src/requirements.txt
@@ -1,3 +1,4 @@
 requests==2.28.1
 boto3==1.26.34
 aws-xray-sdk==2.11.0
+awslambdaric==2.0.4

--- a/lambda/ship-to-opg-metrics/src/requirements_dev.txt
+++ b/lambda/ship-to-opg-metrics/src/requirements_dev.txt
@@ -1,7 +1,7 @@
-moto[sqs]==2.3.0
-moto[secretsmanager]==2.3.0
-coverage==6.2
-pylint==2.12.2
-pytest==6.2.5
-requests-mock
-aws-xray-sdk==2.4.3
+moto[sqs]==4.0.12
+moto[secretsmanager]==4.0.12
+coverage==7.0.0
+pylint==2.15.9
+pytest==7.2.0
+requests-mock==1.10.0
+aws-xray-sdk==2.11.0

--- a/lambda/ship-to-opg-metrics/src/requirements_dev.txt
+++ b/lambda/ship-to-opg-metrics/src/requirements_dev.txt
@@ -5,3 +5,4 @@ pylint==2.15.9
 pytest==7.2.0
 requests-mock==1.10.0
 aws-xray-sdk==2.11.0
+awslambdaric==2.0.4

--- a/lambda/ship-to-opg-metrics/test.Dockerfile
+++ b/lambda/ship-to-opg-metrics/test.Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/python:3.8
+FROM public.ecr.aws/lambda/python:3.9.2022.12.14.07
 
 RUN pip install requests requests_aws4auth
 

--- a/lambda/ship-to-opg-metrics/test.Dockerfile
+++ b/lambda/ship-to-opg-metrics/test.Dockerfile
@@ -1,7 +1,49 @@
-FROM public.ecr.aws/lambda/python:3.9.2022.12.14.07
+# Define function directory
+ARG FUNCTION_DIR="/function"
 
-RUN pip install requests requests_aws4auth
+FROM python:alpine AS python-alpine
+RUN apk add --no-cache \
+    libstdc++
 
-WORKDIR /var/task
-COPY . ./
-CMD ["main.handler"]
+FROM python-alpine as build-image
+
+# Install aws-lambda-cpp build dependencies
+RUN apk add --no-cache \
+    build-base \
+    libtool \
+    autoconf \
+    automake \
+    make \
+    cmake \
+    libcurl
+
+# Include global arg in this stage of the build
+ARG FUNCTION_DIR
+# Create function directory
+RUN mkdir -p ${FUNCTION_DIR}
+
+# Copy function code
+COPY src/test_main.py ${FUNCTION_DIR}
+COPY src/main.py ${FUNCTION_DIR}
+
+COPY src/requirements_dev.txt requirements.txt
+
+# Install the runtime interface client
+RUN python -m pip install --upgrade pip
+RUN python -m pip install \
+        --target ${FUNCTION_DIR} \
+        --requirement requirements.txt
+
+# Multi-stage build: grab a fresh copy of the base image
+FROM python-alpine
+
+# Include global arg in this stage of the build
+ARG FUNCTION_DIR
+# Set working directory to function root directory
+WORKDIR ${FUNCTION_DIR}
+
+# Copy in the build image dependencies
+COPY --from=build-image ${FUNCTION_DIR} ${FUNCTION_DIR}
+
+ENTRYPOINT [ "/usr/local/bin/python", "-m", "awslambdaric" ]
+CMD [ "send_health_events_to_slack.lambda_handler" ]

--- a/lambda/ship-to-opg-metrics/test.Dockerfile
+++ b/lambda/ship-to-opg-metrics/test.Dockerfile
@@ -46,4 +46,4 @@ WORKDIR ${FUNCTION_DIR}
 COPY --from=build-image ${FUNCTION_DIR} ${FUNCTION_DIR}
 
 ENTRYPOINT [ "/usr/local/bin/python", "-m", "awslambdaric" ]
-CMD [ "send_health_events_to_slack.lambda_handler" ]
+CMD ["main.handler"]

--- a/lambda/ship-to-opg-metrics/test.Dockerfile
+++ b/lambda/ship-to-opg-metrics/test.Dockerfile
@@ -1,7 +1,7 @@
 # Define function directory
 ARG FUNCTION_DIR="/function"
 
-FROM python:alpine AS python-alpine
+FROM python:alpine3.16 AS python-alpine
 RUN apk add --no-cache \
     libstdc++
 
@@ -13,6 +13,7 @@ RUN apk add --no-cache \
     libtool \
     autoconf \
     automake \
+    libexecinfo-dev \
     make \
     cmake \
     libcurl


### PR DESCRIPTION
# Purpose

Update the dockerfiles to use a custom base image to overcome out of date dependencies. Also updated the Python libraries used.

## Approach

The latest [ECR Lambda from AWS](https://gallery.ecr.aws/lambda/python) is out of date and appears very slow at reacting to vulnerabilities.

I have instead decided to build our own based on the [Sirius notifier code](https://github.com/ministryofjustice/opg-sirius-infrastructure/blob/main/aws-health-notifier/Dockerfile). 

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
