### PR TITLE
Remove dependabot config in place of renovate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: 'github-actions'
-    pull-request-branch-name:
-      separator: "-"
-    directory: '/'
-    schedule:
-      interval: 'daily'


### PR DESCRIPTION
# Purpose

Remove dependabot config in place of renovate

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
