### PR TITLE
SP-1694 - Build Go Connector without c.Go #minor

### DIFF
--- a/.github/workflows/build_and_upload_go_connector_artifact_job.yml
+++ b/.github/workflows/build_and_upload_go_connector_artifact_job.yml
@@ -19,7 +19,7 @@ jobs:
         id: go_build
         run: |
           cd kinesis_timestream_connector/connector
-          GOARCH=amd64 GOOS=linux go build -tags lambda.norpc -o bootstrap main.go
+          GOARCH=amd64 GOOS=linux CGO_ENABLED=0  go build -tags lambda.norpc -o bootstrap main.go
           echo ::set-output name=artifact_name::bootstrap
       - name: Upload Go executable
         id: upload


### PR DESCRIPTION
# Purpose
Should Stop the Go Lambda from falling over when it's trying to process events as C Go is not present in the new runtime.,


* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
