### PR TITLE
MLPAB-2904 - allow mrlpa metrics role

### DIFF
--- a/terraform/environment/api-keys.tf
+++ b/terraform/environment/api-keys.tf
@@ -102,7 +102,8 @@ module "trusted_service_access_mrlpa_development" {
   secret_recovery_window_in_days     = 0
   secretsmanager_api_keys_kms_key_id = aws_kms_key.api_key.key_id
   identifiers_arns = [
-    "arn:aws:iam::653761790766:role/operator"
+    "arn:aws:iam::653761790766:role/operator",
+    "arn:aws:iam::653761790766:role/opg-metrics-*"
   ]
 }
 
@@ -114,7 +115,8 @@ module "trusted_service_access_mrlpa_preproduction" {
   secret_recovery_window_in_days     = 0
   secretsmanager_api_keys_kms_key_id = aws_kms_key.api_key.key_id
   identifiers_arns = [
-    "arn:aws:iam::792093328875:role/operator"
+    "arn:aws:iam::792093328875:role/operator",
+    "arn:aws:iam::653761790766:role/opg-metrics-preproduction"
   ]
 }
 module "trusted_service_access_mrlpa_production" {
@@ -125,6 +127,7 @@ module "trusted_service_access_mrlpa_production" {
   secret_recovery_window_in_days     = 0
   secretsmanager_api_keys_kms_key_id = aws_kms_key.api_key.key_id
   identifiers_arns = [
-    "arn:aws:iam::313879017102:role/operator"
+    "arn:aws:iam::313879017102:role/operator",
+    "arn:aws:iam::653761790766:role/opg-metrics-production"
   ]
 }

--- a/terraform/environment/event_bus.tf
+++ b/terraform/environment/event_bus.tf
@@ -1,0 +1,3 @@
+resource "aws_cloudwatch_event_bus" "main" {
+  name = local.default_tags.environment-name
+}

--- a/terraform/environment/versions.tf
+++ b/terraform/environment/versions.tf
@@ -1,9 +1,0 @@
-terraform {
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 5.94.0"
-    }
-  }
-  # required_version = "1.11.3"
-}

--- a/terraform/environment/versions.tf
+++ b/terraform/environment/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.94.0"
+    }
+  }
+  # required_version = "1.11.3"
+}


### PR DESCRIPTION
# Purpose

MRLPA is using Eventbridge API destination targets to push metrics. The role used for API destinations needs to be permitted to invoke the api

Fixes Ticket: MLPAB-2904

## Approach

- Add opg-metrics role to identifiers for api keys

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
