### PR TITLE
MLPAB-2997 - replace state role and use new lockfile approach for opg-metrics

### DIFF
--- a/terraform/account/terraform.tf
+++ b/terraform/account/terraform.tf
@@ -5,9 +5,9 @@ terraform {
     encrypt = true
     region  = "eu-west-1"
     assume_role = {
-      role_arn = "arn:aws:iam::311462405659:role/opg-metrics-ci"
+      role_arn = "arn:aws:iam::311462405659:role/opg-metrics-state-access"
     }
-    dynamodb_table = "remote_lock"
+    use_lockfile = true
   }
 }
 

--- a/terraform/environment/terraform.tf
+++ b/terraform/environment/terraform.tf
@@ -5,9 +5,9 @@ terraform {
     encrypt = true
     region  = "eu-west-1"
     assume_role = {
-      role_arn = "arn:aws:iam::311462405659:role/opg-metrics-ci"
+      role_arn = "arn:aws:iam::311462405659:role/opg-metrics-state-access"
     }
-    dynamodb_table = "remote_lock"
+    use_lockfile = true
   }
 }
 


### PR DESCRIPTION
# Purpose

DynamoDB state locking is deprecated.

Fixes Ticket: MLPAB-2997

## Approach

- use new state role and switch to state lockfile

## Learning

- https://developer.hashicorp.com/terraform/language/backend/s3#state-locking
