### PR TITLE
MLPAB-2999 add kms cmk for cloudwatch log groups

### DIFF
--- a/terraform/account/data_sources.tf
+++ b/terraform/account/data_sources.tf
@@ -1,0 +1,1 @@
+data "aws_caller_identity" "current" {}

--- a/terraform/account/kms_keys.tf
+++ b/terraform/account/kms_keys.tf
@@ -4,10 +4,10 @@ module "cloudwatch_log_group_kms_key" {
   alias               = "cloudwatch-log-groups-${local.account_name}"
   decryption_roles    = [local.account_name == "production" ? "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/breakglass" : "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/operator"]
   description         = "KMS Key for Cloudwatch log group encryption ${local.account_name}"
-  encryption_roles    = [local.account_name == "production" ? "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/breakglass" : "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/operator"]
+  encryption_roles    = []
   usage_services = [
-    "logs.eu_west_1.amazonaws.com",
-    "logs.eu_west_2.amazonaws.com",
+    "logs.eu-west-1.amazonaws.com",
+    "logs.eu-west-2.amazonaws.com",
   ]
 
   providers = {

--- a/terraform/account/kms_keys.tf
+++ b/terraform/account/kms_keys.tf
@@ -1,0 +1,17 @@
+module "cloudwatch_log_group_kms_key" {
+  source              = "../modules/kms_key"
+  administrator_roles = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/breakglass"]
+  alias               = "cloudwatch-log-groups-${local.account_name}"
+  decryption_roles    = [local.account_name == "production" ? "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/breakglass" : "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/operator"]
+  description         = "KMS Key for Cloudwatch log group encryption ${local.account_name}"
+  encryption_roles    = [local.account_name == "production" ? "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/breakglass" : "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/operator"]
+  usage_services = [
+    "logs.eu_west_1.amazonaws.com",
+    "logs.eu_west_2.amazonaws.com",
+  ]
+
+  providers = {
+    aws.eu_west_1 = aws
+    aws.eu_west_2 = aws.eu-west-2
+  }
+}

--- a/terraform/account/terraform.tf
+++ b/terraform/account/terraform.tf
@@ -23,3 +23,12 @@ provider "aws" {
     session_name = "opg-metrics-terraform-session"
   }
 }
+
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "eu-west-2"
+  assume_role {
+    role_arn     = "arn:aws:iam::${local.account.account_id}:role/${var.default_role}"
+    session_name = "opg-metrics-terraform-session"
+  }
+}

--- a/terraform/modules/kms_key/.terraform.lock.hcl
+++ b/terraform/modules/kms_key/.terraform.lock.hcl
@@ -1,0 +1,38 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.95.0"
+  constraints = ">= 5.81.0"
+  hashes = [
+    "h1:5TSx6DqOf1wDl94VnmFBd0LS7rj9WeNLzhEH5OR91lQ=",
+    "h1:6a/u1G0pYpKuXlYd4rBiY1MOf/2/u+lsXrqVKX+cyWw=",
+    "h1:EKaysIz3TwN9w2m1qzkYcv0zXjY0poZIb5LqfJ46MYo=",
+    "h1:Ewpt0MOWXnzzSTurMzbPUrx8aks4AZd0UCPlshpTvAg=",
+    "h1:M8cw3yigrk0C73kOegK8QUNWl07tt6N5wrMXrcXvklY=",
+    "h1:PUug/LLWa4GM08rXqnmCVUXj8ibCTvQxgvawhat3bMo=",
+    "h1:jRq8sU+/pFJX179VHfTXeZP+AfjWboeS0T1RgalPTrs=",
+    "h1:lvkTzjc/hlMC55xL+3H2yhRCnrlUCij9gejKOAm62OQ=",
+    "h1:ncMkoXvHvWQqgH1hTdsc+rEmdgcldezZvc1/uVuCOnE=",
+    "h1:pus7tQ5/UchkIkCRh9FriM9AtTIn1k7ZbN0lr7xXCio=",
+    "h1:uMhXkw9xETFOHIPc0IYKK6KAMyX3oet2QyJuzBWKlKk=",
+    "h1:vWiNRFP91pk3d8cbm9JHBwCG3MDqYVXClH9TpT3bh+U=",
+    "h1:wTc87U018nb3IUMvnKeYOZh8zFU2qGPAzHE4Yww4weo=",
+    "h1:wiDMUsumuHQ8CynAX9BPkHmSwG24vZ/3noX/NtVlg7k=",
+    "zh:20aac8c95edd444e659f235d19fa6af9b259c5a70fce19d400539ee88687e7d4",
+    "zh:29c55846fadd19dde0c5108f74d507c296d6c37cabdd466a96d3721a7c261743",
+    "zh:325fa5cb42d58c9203c279450863c49e534672f7101c067af465f9d7f4be3be5",
+    "zh:4f18c643584f7ba554399c0db3dd1c81629dfc2508a8777890f9f3b80b5213b7",
+    "zh:561e38e9cc6f0be5470c187ea8d51047c4133d9cb74cc1c364a9ebe41f40a06b",
+    "zh:6ec2cceed96ca5e47591ef11686614c663b05e112a814d24246a2739066577b6",
+    "zh:710a227c02b8a50f75a82a7f063d2416e85783e02ed91bb22cc12e7a8e11a3cf",
+    "zh:97a2f5e9bf4cf9a38274eddb7967e1cb4e5b04960c7da3603d9b1c15e18b8626",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:bf6bfb01fff8226d86c1b219d67cd96f37bb9312b17d00340e6ff00dda2dbe82",
+    "zh:cba74d606149cbaaa8dfb69f369f2496b851643a879adc24b11515fcece42b66",
+    "zh:d5a2c36739cab677a48f4856958c96be6f018ff0da50d233ca93a3a21aaceca1",
+    "zh:df5d1466144852fe5da4af0628db6f02b5186c59f683e5085705d9b90cacfbc0",
+    "zh:f82d96b45983b3c73b78dced9e344512b7a9adb06e8c1e3e4f422605efbb756d",
+    "zh:fb523f787077270059a8f3ab52c0fc56257c0b3a06f0219be247c8b15ff0ca2a",
+  ]
+}

--- a/terraform/modules/kms_key/data_sources.tf
+++ b/terraform/modules/kms_key/data_sources.tf
@@ -1,0 +1,3 @@
+data "aws_caller_identity" "current" {
+  provider = aws.eu_west_1
+}

--- a/terraform/modules/kms_key/kms.tf
+++ b/terraform/modules/kms_key/kms.tf
@@ -1,0 +1,28 @@
+resource "aws_kms_key" "eu_west_1" {
+  description             = var.description
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+  policy                  = data.aws_iam_policy_document.kms_key.json
+  multi_region            = true
+  provider                = aws.eu_west_1
+}
+
+resource "aws_kms_replica_key" "eu_west_2" {
+  description             = var.description
+  deletion_window_in_days = 7
+  primary_key_arn         = aws_kms_key.eu_west_1.arn
+  policy                  = data.aws_iam_policy_document.kms_key.json
+  provider                = aws.eu_west_2
+}
+
+resource "aws_kms_alias" "eu_west_1" {
+  name          = "alias/${var.alias}"
+  target_key_id = aws_kms_key.eu_west_1.key_id
+  provider      = aws.eu_west_1
+}
+
+resource "aws_kms_alias" "eu_west_2" {
+  name          = "alias/${var.alias}"
+  target_key_id = aws_kms_replica_key.eu_west_2.key_id
+  provider      = aws.eu_west_2
+}

--- a/terraform/modules/kms_key/kms_policy.tf
+++ b/terraform/modules/kms_key/kms_policy.tf
@@ -1,0 +1,126 @@
+data "aws_iam_policy_document" "kms_key" {
+  provider = aws.eu_west_1
+
+  statement {
+    sid    = "Enable Root KMS Permissions"
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+    actions = [
+      "kms:*",
+    ]
+    resources = [
+      "*",
+    ]
+  }
+
+  statement {
+    sid    = "Allow Key to be used for Encryption"
+    effect = "Allow"
+    resources = [
+      "arn:aws:kms:*:${data.aws_caller_identity.current.account_id}:key/*"
+    ]
+    actions = [
+      "kms:Encrypt",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:DescribeKey",
+    ]
+
+    principals {
+      type        = "AWS"
+      identifiers = var.encryption_roles
+    }
+
+    dynamic "condition" {
+      for_each = length(var.usage_services) > 0 ? [1] : []
+      content {
+        test     = "StringLike"
+        variable = "kms:ViaService"
+
+        values = var.usage_services
+      }
+    }
+  }
+
+  statement {
+    sid    = "Allow Key to be used for Decryption"
+    effect = "Allow"
+    resources = [
+      "arn:aws:kms:*:${data.aws_caller_identity.current.account_id}:key/*"
+    ]
+    actions = [
+      "kms:Decrypt",
+      "kms:DescribeKey",
+    ]
+
+    principals {
+      type        = "AWS"
+      identifiers = var.decryption_roles
+    }
+
+    dynamic "condition" {
+      for_each = length(var.usage_services) > 0 ? [1] : []
+      content {
+        test     = "StringLike"
+        variable = "kms:ViaService"
+
+        values = var.usage_services
+      }
+    }
+  }
+
+  statement {
+    sid    = "General View Access"
+    effect = "Allow"
+    resources = [
+      "arn:aws:kms:*:${data.aws_caller_identity.current.account_id}:key/*"
+    ]
+    actions = [
+      "kms:DescribeKey",
+      "kms:GetKeyPolicy",
+      "kms:GetKeyRotationStatus",
+      "kms:List*",
+    ]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+      ]
+    }
+  }
+
+  statement {
+    sid    = "Key Administrator"
+    effect = "Allow"
+    resources = [
+      "arn:aws:kms:*:${data.aws_caller_identity.current.account_id}:key/*"
+    ]
+    actions = [
+      "kms:Create*",
+      "kms:Describe*",
+      "kms:Decrypt",
+      "kms:Enable*",
+      "kms:List*",
+      "kms:Put*",
+      "kms:Update*",
+      "kms:Revoke*",
+      "kms:Disable*",
+      "kms:Get*",
+      "kms:Delete*",
+      "kms:TagResource",
+      "kms:UntagResource",
+      "kms:ScheduleKeyDeletion",
+      "kms:CancelKeyDeletion",
+      "kms:ReplicateKey",
+    ]
+
+    principals {
+      type        = "AWS"
+      identifiers = var.administrator_roles
+    }
+  }
+}

--- a/terraform/modules/kms_key/kms_policy.tf
+++ b/terraform/modules/kms_key/kms_policy.tf
@@ -29,11 +29,6 @@ data "aws_iam_policy_document" "kms_key" {
       "kms:DescribeKey",
     ]
 
-    # principals {
-    #   type        = "AWS"
-    #   identifiers = var.encryption_roles
-    # }
-
     dynamic "principals" {
       for_each = length(var.encryption_roles) > 0 ? [1] : []
       content {

--- a/terraform/modules/kms_key/kms_policy.tf
+++ b/terraform/modules/kms_key/kms_policy.tf
@@ -29,9 +29,25 @@ data "aws_iam_policy_document" "kms_key" {
       "kms:DescribeKey",
     ]
 
-    principals {
-      type        = "AWS"
-      identifiers = var.encryption_roles
+    # principals {
+    #   type        = "AWS"
+    #   identifiers = var.encryption_roles
+    # }
+
+    dynamic "principals" {
+      for_each = length(var.encryption_roles) > 0 ? [1] : []
+      content {
+        type        = "AWS"
+        identifiers = var.encryption_roles
+      }
+    }
+
+    dynamic "principals" {
+      for_each = length(var.usage_services) > 0 ? [1] : []
+      content {
+        type        = "Service"
+        identifiers = var.usage_services
+      }
     }
 
     dynamic "condition" {
@@ -56,9 +72,20 @@ data "aws_iam_policy_document" "kms_key" {
       "kms:DescribeKey",
     ]
 
-    principals {
-      type        = "AWS"
-      identifiers = var.decryption_roles
+    dynamic "principals" {
+      for_each = length(var.decryption_roles) > 0 ? [1] : []
+      content {
+        type        = "AWS"
+        identifiers = var.decryption_roles
+      }
+    }
+
+    dynamic "principals" {
+      for_each = length(var.usage_services) > 0 ? [1] : []
+      content {
+        type        = "Service"
+        identifiers = var.usage_services
+      }
     }
 
     dynamic "condition" {

--- a/terraform/modules/kms_key/outputs.tf
+++ b/terraform/modules/kms_key/outputs.tf
@@ -1,0 +1,7 @@
+output "eu_west_1" {
+  value = aws_kms_key.eu_west_1
+}
+
+output "eu_west_2" {
+  value = aws_kms_replica_key.eu_west_2
+}

--- a/terraform/modules/kms_key/terraform.tf
+++ b/terraform/modules/kms_key/terraform.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.81.0"
+      configuration_aliases = [
+        aws.eu_west_1,
+        aws.eu_west_2
+      ]
+    }
+  }
+  required_version = ">= 1.7.3"
+}

--- a/terraform/modules/kms_key/variables.tf
+++ b/terraform/modules/kms_key/variables.tf
@@ -1,0 +1,29 @@
+variable "administrator_roles" {
+  description = "List of Role ARNs allowed to administer the KMS Key"
+  type        = list(string)
+}
+
+variable "alias" {
+  description = "KMS Key Alias"
+  type        = string
+}
+
+variable "decryption_roles" {
+  description = "List of Role ARNs allowed to use the KMS Key for Decryption"
+  type        = list(string)
+}
+
+variable "description" {
+  description = "KMS Key Description"
+  type        = string
+}
+
+variable "encryption_roles" {
+  description = "List of Role ARNs allowed to use the KMS Key for Encryption"
+  type        = list(string)
+}
+
+variable "usage_services" {
+  description = "List of AWS Service that the usage roles can use the KMS "
+  type        = list(string)
+}


### PR DESCRIPTION
# Purpose

Use KMS customer managed keys for encrypting data in services

Fixes Ticket: MLPAB-2999

## Approach

- add module for creating KMS CMKs
- add KMS key module instance for cloudwatch log groups

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
