### PR TITLE
MLPAB-2999 - rename key as it lives in a shared account

### DIFF
--- a/terraform/account/data_sources.tf
+++ b/terraform/account/data_sources.tf
@@ -1,1 +1,3 @@
 data "aws_caller_identity" "current" {}
+
+data "aws_default_tags" "current" {}

--- a/terraform/account/kms_keys.tf
+++ b/terraform/account/kms_keys.tf
@@ -1,7 +1,7 @@
 module "cloudwatch_log_group_kms_key" {
   source              = "../modules/kms_key"
   administrator_roles = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/breakglass"]
-  alias               = "cloudwatch-log-groups-${local.account_name}"
+  alias               = "${data.aws_default_tags.current.tags.application}-cloudwatch-log-groups-${local.account_name}"
   decryption_roles    = [local.account_name == "production" ? "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/breakglass" : "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/operator"]
   description         = "KMS Key for Cloudwatch log group encryption ${local.account_name}"
   encryption_roles    = []

--- a/terraform/account/kms_keys.tf
+++ b/terraform/account/kms_keys.tf
@@ -2,7 +2,7 @@ module "cloudwatch_log_group_kms_key" {
   source              = "../modules/kms_key"
   administrator_roles = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/breakglass"]
   alias               = "${data.aws_default_tags.current.tags.application}-cloudwatch-log-groups-${local.account_name}"
-  decryption_roles    = [local.account_name == "production" ? "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/breakglass" : "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/operator"]
+  decryption_roles    = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/operator"]
   description         = "KMS key for opg-metrics cloudwatch log group encryption ${local.account_name}"
   encryption_roles    = []
   usage_services = [

--- a/terraform/account/kms_keys.tf
+++ b/terraform/account/kms_keys.tf
@@ -3,7 +3,7 @@ module "cloudwatch_log_group_kms_key" {
   administrator_roles = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/breakglass"]
   alias               = "${data.aws_default_tags.current.tags.application}-cloudwatch-log-groups-${local.account_name}"
   decryption_roles    = [local.account_name == "production" ? "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/breakglass" : "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/operator"]
-  description         = "KMS Key for Cloudwatch log group encryption ${local.account_name}"
+  description         = "KMS key for opg-metrics cloudwatch log group encryption ${local.account_name}"
   encryption_roles    = []
   usage_services = [
     "logs.eu-west-1.amazonaws.com",

--- a/terraform/account/network.tf
+++ b/terraform/account/network.tf
@@ -1,7 +1,7 @@
 module "network" {
   source                         = "../modules/network"
   cidr                           = "10.162.0.0/16"
-  tags                           = local.tags
+  tags                           = local.default_tags
   default_security_group_ingress = [{}]
   default_security_group_egress  = [{}]
 }

--- a/terraform/account/terraform.tf
+++ b/terraform/account/terraform.tf
@@ -18,6 +18,9 @@ variable "default_role" {
 
 provider "aws" {
   region = "eu-west-1"
+  default_tags {
+    tags = local.default_tags
+  }
   assume_role {
     role_arn     = "arn:aws:iam::${local.account.account_id}:role/${var.default_role}"
     session_name = "opg-metrics-terraform-session"
@@ -27,6 +30,9 @@ provider "aws" {
 provider "aws" {
   region = "eu-west-2"
   alias  = "eu-west-2"
+  default_tags {
+    tags = local.default_tags
+  }
   assume_role {
     role_arn     = "arn:aws:iam::${local.account.account_id}:role/${var.default_role}"
     session_name = "opg-metrics-terraform-session"

--- a/terraform/account/variables.tf
+++ b/terraform/account/variables.tf
@@ -20,5 +20,5 @@ locals {
     source-code      = "https://github.com/ministryofjustice/opg-metrics"
   }
 
-  tags = local.mandatory_moj_tags
+  default_tags = local.mandatory_moj_tags
 }

--- a/terraform/account/variables.tf
+++ b/terraform/account/variables.tf
@@ -12,7 +12,7 @@ locals {
 
   mandatory_moj_tags = {
     business-unit    = "OPG"
-    application      = "opg-metrics-shared"
+    application      = "opg-metrics"
     environment-name = local.account_name
     owner            = "OPGOPS opgteam+opgmetrics@digital.justice.gov.uk"
     is-production    = "false"


### PR DESCRIPTION
# Purpose

KMS Key aliases need to be unique in the account

Fixes Ticket: MLPAB-2999

## Approach

- rename key to include application name tag