### PR TITLE
Revert API gateway log group encryption

### DIFF
--- a/terraform/account/kms_keys.tf
+++ b/terraform/account/kms_keys.tf
@@ -1,10 +1,13 @@
 module "cloudwatch_log_group_kms_key" {
-  source              = "../modules/kms_key"
-  administrator_roles = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/breakglass"]
-  alias               = "${data.aws_default_tags.current.tags.application}-cloudwatch-log-groups-${local.account_name}"
-  decryption_roles    = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/operator"]
-  description         = "KMS key for opg-metrics cloudwatch log group encryption ${local.account_name}"
-  encryption_roles    = []
+  source = "../modules/kms_key"
+  administrator_roles = [
+    "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/breakglass",
+    "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/opg-metrics-ci"
+  ]
+  alias            = "${data.aws_default_tags.current.tags.application}-cloudwatch-log-groups-${local.account_name}"
+  decryption_roles = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/operator"]
+  description      = "KMS key for opg-metrics cloudwatch log group encryption ${local.account_name}"
+  encryption_roles = []
   usage_services = [
     "logs.eu-west-1.amazonaws.com",
     "logs.eu-west-2.amazonaws.com",

--- a/terraform/environment/api-gateway.tf
+++ b/terraform/environment/api-gateway.tf
@@ -44,8 +44,8 @@ locals {
 }
 
 resource "aws_cloudwatch_log_group" "kinesis_stream_api_gateway" {
-  name              = "API-Gateway-Execution-Logs_${aws_api_gateway_rest_api.kinesis_stream_api_gateway.id}/${local.environment_name}"
-  kms_key_id        = data.aws_kms_alias.cloudwatch_application_logs_encryption.target_key_arn
+  name = "API-Gateway-Execution-Logs_${aws_api_gateway_rest_api.kinesis_stream_api_gateway.id}/${local.environment_name}"
+  # kms_key_id        = data.aws_kms_alias.cloudwatch_application_logs_encryption.target_key_arn
   retention_in_days = 7
 }
 


### PR DESCRIPTION
# Purpose

Path to live failed with a permission or missing key error

## Approach

- add ci as key admin
- remove encryption from api gateway log group
