### PR TITLE
MLPAB-3009 - add makefile target to build artifact required for apply

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,31 @@
+#COLORS
+GREEN  := $(shell tput -Txterm setaf 2)
+WHITE  := $(shell tput -Txterm setaf 7)
+YELLOW := $(shell tput -Txterm setaf 3)
+RESET  := $(shell tput -Txterm sgr0)
+
+# Add the following 'help' target to your Makefile
+# And add help text after each target name starting with '\#\#'
+# A category can be added with @category
+# This was made possible by https://gist.github.com/prwhite/8168133#gistcomment-1727513
+HELP_FUN = \
+		%help; \
+		while(<>) { push @{$$help{$$2 // 'options'}}, [$$1, $$3] if /^([a-zA-Z0-9\-]+)\s*:.*\#\#(?:@([a-zA-Z\-]+))?\s(.*)$$/ }; \
+		print "usage: make [target]\n\n"; \
+		for (sort keys %help) { \
+		print "${WHITE}$$_:${RESET}\n"; \
+		for (@{$$help{$$_}}) { \
+		$$sep = " " x (32 - length $$_->[0]); \
+		print "  ${YELLOW}$$_->[0]${RESET}$$sep${GREEN}$$_->[1]${RESET}\n"; \
+		}; \
+		print "\n"; }
+
+blddir := kinesis_timestream_connector/connector
+
+help: ##@other Show this help.
+	@perl -e '$(HELP_FUN)' $(MAKEFILE_LIST)
+
+build_connector: ##@build Builds lambda go connector needed for terraform apply
+	cd kinesis_timestream_connector/connector && \
+	GOARCH=amd64 GOOS=linux CGO_ENABLED=0  go build -tags lambda.norpc -o ../../kinesis-go-application/bootstrap main.go
+


### PR DESCRIPTION
# Purpose

Support working locally with terraform

Fixes Ticket: MLPAB-3009

## Approach

- add make target to build the go connector app required for a terraform environment plan

## Learning

- https://gist.github.com/prwhite/8168133#gistcomment-1727513
