### PR TITLE
MLPAB-3019 - Fix rotate API keys job

### DIFF
--- a/.github/workflows/path_to_live_workflow.yml
+++ b/.github/workflows/path_to_live_workflow.yml
@@ -66,6 +66,7 @@ jobs:
     with:
       terraform_path: 'terraform/account'
       workspace: development
+      apply_plan: true
     secrets:
       aws_access_key_id_actions: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
       aws_secret_access_key_actions: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}

--- a/.github/workflows/path_to_live_workflow.yml
+++ b/.github/workflows/path_to_live_workflow.yml
@@ -80,6 +80,7 @@ jobs:
       download_artifact: true
       download_go_artifact_name: ${{ needs.build_go.outputs.artifact_name }}
       download_go_artifact_path_name: 'kinesis-go-application'
+      apply_plan: true
     secrets:
       aws_access_key_id_actions: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
       aws_secret_access_key_actions: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}

--- a/.github/workflows/pr_workflow.yml
+++ b/.github/workflows/pr_workflow.yml
@@ -82,6 +82,7 @@ jobs:
       download_artifact: true
       download_go_artifact_name: ${{ needs.build_go.outputs.artifact_name }}
       download_go_artifact_path_name: 'kinesis-go-application'
+      apply_plan: false
     secrets:
       aws_access_key_id_actions: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
       aws_secret_access_key_actions: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}

--- a/.github/workflows/pr_workflow.yml
+++ b/.github/workflows/pr_workflow.yml
@@ -67,6 +67,7 @@ jobs:
     with:
       terraform_path: 'terraform/account'
       workspace: development
+      apply_plan: false
     secrets:
       aws_access_key_id_actions: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
       aws_secret_access_key_actions: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}

--- a/.github/workflows/rotate_api_keys_workflow.yml
+++ b/.github/workflows/rotate_api_keys_workflow.yml
@@ -1,8 +1,13 @@
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 2 * * *' # Every 2 a.m.
 
 jobs:
+  build_go:
+    name: Build Go
+    uses: ./.github/workflows/build_and_upload_go_connector_artifact_job.yml
+
   taint_api_keys:
     name: Taint API Keys
     runs-on: ubuntu-latest
@@ -53,47 +58,17 @@ jobs:
         working-directory: ./terraform/environment
 
   replace_api_keys:
-    name: Replace API Keys
-    runs-on: ubuntu-latest
-    needs: ['taint_api_keys']
-    steps:
-      - name: checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-        with:
-          fetch-depth: 2
-
-      - uses: unfor19/install-aws-cli-action@e8b481e524a99f37fbd39fdc1dcb3341ab091367 # v1
-      - name: "Parse terraform version [directory: ./terraform/environment]"
-        id: tf_version
-        uses: ministryofjustice/opg-github-actions/.github/actions/terraform-version@9a39e099657fda2d7389e1fab3c333ad3c704212 # v3.1.3
-        with:
-          terraform_directory: ./terraform/environment
-      - name: "Terraform version [${{ steps.tf_version.outputs.version }}]"
-        run: echo "terraform version [${{ steps.tf_version.outputs.version }}]" >> $GITHUB_STEP_SUMMARY
-        working-directory: ./terraform/environment
-      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
-        with:
-          terraform_version: ${{ steps.tf_version.outputs.version }}
-          terraform_wrapper: false
-
-
-      - name: Configure AWS Credentials For Terraform
-        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}
-          aws-region: eu-west-1
-          role-duration-seconds: 3600
-          role-session-name: OPGMetricsECRGithubAction
-
-      - name: Terraform Init
-        run: terraform init -input=false
-        working-directory: ./terraform/environment
-
-      - name: Terraform replace api keys
-        env:
-          TF_WORKSPACE: development
-          TF_VAR_timestream_connector_artifact_name: bootstrap
-        run: |
-          terraform apply | ~/work/opg-metrics/opg-metrics/scripts/pipeline/redact_output.sh
-        working-directory: ./terraform/environment
+    name: Terraform Environment
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    needs: ['taint_api_keys', 'build_go']
+    uses: ./.github/workflows/terraform_plan_job.yml
+    with:
+      terraform_path: 'terraform/environment'
+      workspace: development
+      download_artifact: true
+      download_go_artifact_name: ${{ needs.build_go.outputs.artifact_name }}
+      download_go_artifact_path_name: 'kinesis-go-application'
+      apply_plan: true
+    secrets:
+      aws_access_key_id_actions: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
+      aws_secret_access_key_actions: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}

--- a/.github/workflows/terraform_plan_job.yml
+++ b/.github/workflows/terraform_plan_job.yml
@@ -22,6 +22,11 @@ on:
         description: 'Local go artifact path location'
         required: false
         type: string
+      apply_plan:
+        description: 'Apply terraform plan when true'
+        required: false
+        default: false
+        type: boolean
     secrets:
       aws_access_key_id_actions:
         required: true
@@ -102,7 +107,7 @@ jobs:
         env:
           TF_WORKSPACE: ${{ inputs.workspace }}
           TF_VAR_timestream_connector_artifact_name: ${{ inputs.download_go_artifact_name }}
-        if: github.ref == 'refs/heads/main'
+        if: ${{ inputs.apply_plan == true }}
         run: |
-          terraform apply -lock-timeout=300s -input=false -auto-approve -parallelism=30 terraform.plan
+          echo "apply plan"
         working-directory: ./${{ inputs.terraform_path }}

--- a/.github/workflows/terraform_plan_job.yml
+++ b/.github/workflows/terraform_plan_job.yml
@@ -109,5 +109,5 @@ jobs:
           TF_VAR_timestream_connector_artifact_name: ${{ inputs.download_go_artifact_name }}
         if: ${{ inputs.apply_plan == true }}
         run: |
-          echo "apply plan"
+          terraform apply -lock-timeout=300s -input=false -auto-approve -parallelism=30 terraform.plan
         working-directory: ./${{ inputs.terraform_path }}


### PR DESCRIPTION
use terraform_plan_job in api keys rotation workflow

# Purpose

Rotate API keys job fails to apply because the connector artifact for lambda is missing

Fixes Ticket: MLPAB-3019

## Approach

- add apply_plan input to terraform plan job
- set apply_plan = false for pr workflows account and environment jobs
- set apply_plan = true for path to live account and environment jobs
- set apply_plan = true for api key rotate job
- add build artifact to api key job (job fails without artifact being present
- allow running api key rotate from github ui

## Learning



## Checklist

* [x] I have performed a self-review of my own code
~* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant~
~* [ ] I have added tests to prove my work~
~* [ ] The product team have tested these changes~
