### PR TITLE
MLPAB-3004 - upgrade python version and base docker images

### DIFF
--- a/.github/workflows/python_build_test_job.yml
+++ b/.github/workflows/python_build_test_job.yml
@@ -17,10 +17,10 @@ jobs:
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Set up Python 3.8
+      - name: Set up Python 3.13.3
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: 3.8
+          python-version: 3.13.3
 
       - name: Install dependencies
         run: |

--- a/lambda/clsf-to-sqs/Dockerfile
+++ b/lambda/clsf-to-sqs/Dockerfile
@@ -1,7 +1,7 @@
 # Define function directory
 ARG FUNCTION_DIR="/function"
 
-FROM python:alpine3.16@sha256:9efc6e155f287eb424ede74aeff198be75ae04504b1e42e87ec9f221e7410f2d AS python-alpine
+FROM python:3.13.3-alpine3.21 AS python-alpine
 RUN apk add --no-cache \
     libstdc++
 

--- a/lambda/ship-to-opg-metrics/Dockerfile
+++ b/lambda/ship-to-opg-metrics/Dockerfile
@@ -1,7 +1,7 @@
 # Define function directory
 ARG FUNCTION_DIR="/function"
 
-FROM python:alpine3.16@sha256:9efc6e155f287eb424ede74aeff198be75ae04504b1e42e87ec9f221e7410f2d AS python-alpine
+FROM python:3.13.3-alpine3.21 AS python-alpine
 RUN apk add --no-cache \
     libstdc++
 


### PR DESCRIPTION
# Purpose

There are vulnerabilities reported for the current base image of the python lambda functions

Fixes Ticket: MLPAB-3004

## Approach

- upgrade python version
- upgrade image version

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
