### PR TITLE
MLPAB-2999 - add kms cmk for kinesis stream and api gateway log group

### DIFF
--- a/terraform/account/kms_keys.tf
+++ b/terraform/account/kms_keys.tf
@@ -36,8 +36,8 @@ module "kinesis_kms_key" {
   description      = "KMS key for opg-metrics kinesis encryption ${local.account_name}"
   encryption_roles = []
   usage_services = [
-    "logs.eu-west-1.amazonaws.com",
-    "logs.eu-west-2.amazonaws.com",
+    "kinesis.eu-west-1.amazonaws.com",
+    "kinesis.eu-west-2.amazonaws.com",
   ]
 
   providers = {


### PR DESCRIPTION
# Purpose

Use customer managed keys to control who has access to encrypt and decrypt data

Fixes Ticket: MLPAB-2999

## Approach

- allow apigateway role to encrypt with cloudwatch log group kms key
- create a kms key for kinesis

## Learning

- https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html#set-up-access-logging-permissions
- https://docs.aws.amazon.com/streams/latest/dev/creating-using-sse-master-keys.html

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
