### PR TITLE
MLPAB-2999 - Allow attachment of persistent resources for kms key policy

### DIFF
--- a/terraform/account/kms_keys.tf
+++ b/terraform/account/kms_keys.tf
@@ -16,6 +16,7 @@ module "cloudwatch_log_group_kms_key" {
     "logs.eu-west-1.amazonaws.com",
     "logs.eu-west-2.amazonaws.com",
   ]
+  enable_grant_for_resources = false
 
   providers = {
     aws.eu_west_1 = aws
@@ -33,12 +34,12 @@ module "kinesis_kms_key" {
   decryption_roles = [
     "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/operator"
   ]
-  description      = "KMS key for opg-metrics kinesis encryption ${local.account_name}"
-  encryption_roles = []
-  usage_services = [
-    "kinesis.eu-west-1.amazonaws.com",
-    "kinesis.eu-west-2.amazonaws.com",
+  description = "KMS key for opg-metrics kinesis encryption ${local.account_name}"
+  encryption_roles = [
+    "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/LambdaKinesisRole"
   ]
+  usage_services             = []
+  enable_grant_for_resources = true
 
   providers = {
     aws.eu_west_1 = aws

--- a/terraform/modules/kms_key/kms_policy.tf
+++ b/terraform/modules/kms_key/kms_policy.tf
@@ -145,4 +145,28 @@ data "aws_iam_policy_document" "kms_key" {
       identifiers = var.administrator_roles
     }
   }
+  dynamic "statement" {
+    for_each = length(concat(var.encryption_roles, decryption_roles)) > 0 && var.enable_grant_for_resources ? [1] : []
+    content {
+      sid    = "Allow attachment of persistent resources"
+      effect = "Allow"
+      resources = [
+        "arn:aws:kms:*:${data.aws_caller_identity.current.account_id}:key/*"
+      ]
+      actions = [
+        "kms:CreateGrant",
+        "kms:ListGrants",
+        "kms:RevokeGrant"
+      ]
+      principals {
+        type        = "AWS"
+        identifiers = concat(var.encryption_roles, decryption_roles)
+      }
+      condition {
+        test     = "Bool"
+        variable = "kms:GrantIsForAWSResource"
+        values   = "true"
+      }
+    }
+  }
 }

--- a/terraform/modules/kms_key/variables.tf
+++ b/terraform/modules/kms_key/variables.tf
@@ -27,3 +27,8 @@ variable "usage_services" {
   description = "List of AWS Service that the usage roles can use the KMS "
   type        = list(string)
 }
+
+variable "enable_grant_for_resources" {
+  description = "add policy condition to allow roles to create grants for "
+  type        = bool
+}

--- a/terraform/modules/kms_key/variables.tf
+++ b/terraform/modules/kms_key/variables.tf
@@ -29,6 +29,6 @@ variable "usage_services" {
 }
 
 variable "enable_grant_for_resources" {
-  description = "add policy condition to allow roles to create grants for "
+  description = "add policy condition to allow roles to create grants for resources"
   type        = bool
 }


### PR DESCRIPTION
# Purpose

An invalid principle caused the pervious merge to fail

Fixes Ticket: MLPAB-2999

## Approach

- use correct principle for kms keys
- allow attachment of resources in kms key policy

## Learning

- https://docs.aws.amazon.com/streams/latest/dev/creating-using-sse-master-keys.html

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
